### PR TITLE
Switch to JWTs for authentication

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -164,6 +164,6 @@ func (ts *TestSuite) testAccountPlayerNamesToIDsFallback(t *testing.T) {
 }
 
 func (ts *TestSuite) testAccountVerifySecurityLocation(t *testing.T) {
-	rec := ts.Get(ts.Server, "/user/security/location", nil, nil)
+	rec := ts.Get(t, ts.Server, "/user/security/location", nil, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/authlib_injector_test.go
+++ b/authlib_injector_test.go
@@ -46,7 +46,7 @@ func TestAuthlibInjector(t *testing.T) {
 }
 
 func (ts *TestSuite) testAuthlibInjectorRoot(t *testing.T) {
-	rec := ts.Get(ts.Server, "/authlib-injector", nil, nil)
+	rec := ts.Get(t, ts.Server, "/authlib-injector", nil, nil)
 	ts.CheckAuthlibInjectorHeader(t, ts.App, rec)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -60,7 +60,7 @@ func (ts *TestSuite) testAuthlibInjectorRoot(t *testing.T) {
 }
 
 func (ts *TestSuite) testAuthlibInjectorRootFallback(t *testing.T) {
-	rec := ts.Get(ts.Server, "/authlib-injector", nil, nil)
+	rec := ts.Get(t, ts.Server, "/authlib-injector", nil, nil)
 	ts.CheckAuthlibInjectorHeader(t, ts.App, rec)
 	assert.Equal(t, http.StatusOK, rec.Code)
 

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ type FallbackAPIServer struct {
 	CacheTTLSeconds int
 }
 
-type anonymousLoginConfig struct {
+type transientUsersConfig struct {
 	Allow         bool
 	UsernameRegex string
 	Password      string
@@ -68,7 +68,7 @@ type Config struct {
 	AllowSkins                 bool
 	AllowCapes                 bool
 	FallbackAPIServers         []FallbackAPIServer
-	AnonymousLogin             anonymousLoginConfig
+	TransientUsers             transientUsersConfig
 	RegistrationNewPlayer      registrationNewPlayerConfig
 	RegistrationExistingPlayer registrationExistingPlayerConfig
 	SignPublicKeys             bool
@@ -114,7 +114,7 @@ func DefaultConfig() Config {
 		MinPasswordLength:        1,
 		TokenStaleSec:            0,
 		TokenExpireSec:           0,
-		AnonymousLogin: anonymousLoginConfig{
+		TransientUsers: transientUsersConfig{
 			Allow: false,
 		},
 		RegistrationNewPlayer: registrationNewPlayerConfig{

--- a/config.go
+++ b/config.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"github.com/BurntSushi/toml"
 	"log"
-	"lukechampine.com/blake3"
 	"os"
 	"path"
 )
@@ -73,7 +72,9 @@ type Config struct {
 	RegistrationNewPlayer      registrationNewPlayerConfig
 	RegistrationExistingPlayer registrationExistingPlayerConfig
 	SignPublicKeys             bool
-	EnableTokenExpiry          bool
+	AllowMultipleAccessTokens  bool
+	TokenExpireSec             int
+	TokenStaleSec              int
 	DefaultPreferredLanguage   string
 	SkinSizeLimit              int
 	AllowChangingPlayerName    bool
@@ -111,7 +112,8 @@ func DefaultConfig() Config {
 		AllowSkins:               true,
 		AllowCapes:               true,
 		MinPasswordLength:        1,
-		EnableTokenExpiry:        false,
+		TokenStaleSec:            0,
+		TokenExpireSec:           0,
 		AnonymousLogin: anonymousLoginConfig{
 			Allow: false,
 		},
@@ -157,13 +159,6 @@ func ReadOrCreateConfig(path string) *Config {
 	log.Println("Loaded config:", config)
 
 	return &config
-}
-
-func KeyB3Sum512(key *rsa.PrivateKey) []byte {
-	der := Unwrap(x509.MarshalPKCS8PrivateKey(key))
-
-	sum := blake3.Sum512(der)
-	return sum[:]
 }
 
 func ReadOrCreateKey(config *Config) *rsa.PrivateKey {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -44,10 +44,10 @@ Other available options:
         ServicesURL = https://example.com/yggdrasil/minecraftservices
         ```
 
-- `[AnonymousLogin]`: Allow certain usernames to authenticate with a shared password, without registering. Useful for supporting bot accounts.
+- `[TransientLogin]`: Allow certain usernames to authenticate with a shared password, without registering. Useful for supporting bot accounts.
     - `Allow`: Boolean. Default value: `false`.
-    - `UsernameRegex`: If a username matches this regular expression, it will be allowed to log in with the shared password. Use `".*"` to allow anonymous login for any username. String. Example value: `"[Bot] .*"`.
-    - `Password`: The shared password for anonymous login. Not restricted by `MinPasswordLength`. String. Example value: `"hunter2"`.
+    - `UsernameRegex`: If a username matches this regular expression, it will be allowed to log in with the shared password. Use `".*"` to allow transient login for any username. String. Example value: `"[Bot] .*"`.
+    - `Password`: The shared password for transient login. Not restricted by `MinPasswordLength`. String. Example value: `"hunter2"`.
 - `[RegistrationNewPlayer]`: Registration policy for new players.
     - `Allow`: Boolean. Default value: `true`.
     - `AllowChoosingUUID`: Allow new users to choose the UUID for their account. Boolean. Default value: `false`.

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
             # it should be "out-of-band" with other tooling (eg. gomod2nix).
             # To begin with it is recommended to set this, but one must
             # remeber to bump this hash when your dependencies change.
-            vendorSha256 = "sha256-GDUxC/TYUurvTuCpyiwn9NbnhTIj0sg/Jbby7oPXFMo=";
+            vendorSha256 = "sha256-YNOTEza43Uvl2FaU4DiFo3GLmnn/o106pMnHyjQ+Je4=";
 
             outputs = [ "out" ];
             patches = [

--- a/front.go
+++ b/front.go
@@ -1142,8 +1142,8 @@ func FrontLogin(app *App) func(c echo.Context) error {
 		username := c.FormValue("username")
 		password := c.FormValue("password")
 
-		if AnonymousLoginEligible(app, username) {
-			setErrorMessage(&c, "Anonymous accounts cannot access the web interface.")
+		if TransientLoginEligible(app, username) {
+			setErrorMessage(&c, "Transient accounts cannot access the web interface.")
 			return c.Redirect(http.StatusSeeOther, failureURL)
 		}
 

--- a/front.go
+++ b/front.go
@@ -1082,7 +1082,7 @@ func FrontRegister(app *App) func(c echo.Context) error {
 			Username:          username,
 			PasswordSalt:      passwordSalt,
 			PasswordHash:      passwordHash,
-			TokenPairs:        []TokenPair{},
+			Clients:           []Client{},
 			PlayerName:        username,
 			FallbackPlayer:    accountUUID,
 			PreferredLanguage: app.Config.DefaultPreferredLanguage,

--- a/front_test.go
+++ b/front_test.go
@@ -217,26 +217,26 @@ func (ts *TestSuite) testRateLimit(t *testing.T) {
 
 	// Login should fail the first time due to missing account, then
 	// soon get rate-limited
-	rec := ts.PostForm(ts.Server, "/drasl/login", form, nil, nil)
+	rec := ts.PostForm(t, ts.Server, "/drasl/login", form, nil, nil)
 	ts.loginShouldFail(t, rec, "User not found!")
-	rec = ts.PostForm(ts.Server, "/drasl/login", form, nil, nil)
+	rec = ts.PostForm(t, ts.Server, "/drasl/login", form, nil, nil)
 	ts.loginShouldFail(t, rec, "User not found!")
-	rec = ts.PostForm(ts.Server, "/drasl/login", form, nil, nil)
+	rec = ts.PostForm(t, ts.Server, "/drasl/login", form, nil, nil)
 	ts.loginShouldFail(t, rec, "Too many requests. Try again later.")
 
 	// Static paths should not be rate-limited
-	rec = ts.Get(ts.Server, "/drasl/registration", nil, nil)
+	rec = ts.Get(t, ts.Server, "/drasl/registration", nil, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	rec = ts.Get(ts.Server, "/drasl/registration", nil, nil)
+	rec = ts.Get(t, ts.Server, "/drasl/registration", nil, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	rec = ts.Get(ts.Server, "/drasl/registration", nil, nil)
+	rec = ts.Get(t, ts.Server, "/drasl/registration", nil, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func (ts *TestSuite) testBodyLimit(t *testing.T) {
 	form := url.Values{}
 	form.Set("bogus", Unwrap(RandomHex(2048)))
-	rec := ts.PostForm(ts.Server, "/drasl/login", form, nil, nil)
+	rec := ts.PostForm(t, ts.Server, "/drasl/login", form, nil, nil)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 }
 
@@ -252,7 +252,7 @@ func (ts *TestSuite) testRegistrationNewPlayer(t *testing.T) {
 		form.Set("password", TEST_PASSWORD)
 		form.Set("email", "mail@example.com")
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "You are now covered in bee stings.", returnURL)
 	}
 	{
@@ -260,7 +260,7 @@ func (ts *TestSuite) testRegistrationNewPlayer(t *testing.T) {
 		form := url.Values{}
 		form.Set("username", usernameA)
 		form.Set("password", TEST_PASSWORD)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldSucceed(t, rec)
 		browserTokenCookie := getCookie(rec, "browserToken")
 
@@ -303,7 +303,7 @@ func (ts *TestSuite) testRegistrationNewPlayer(t *testing.T) {
 		form.Set("username", usernameB)
 		form.Set("password", TEST_PASSWORD)
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldSucceed(t, rec)
 		browserTokenCookie := getCookie(rec, "browserToken")
 
@@ -329,7 +329,7 @@ func (ts *TestSuite) testRegistrationNewPlayer(t *testing.T) {
 		form.Set("username", usernameA)
 		form.Set("password", TEST_PASSWORD)
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 		ts.registrationShouldFail(t, rec, "That username is taken.", returnURL)
 	}
@@ -339,7 +339,7 @@ func (ts *TestSuite) testRegistrationNewPlayer(t *testing.T) {
 		form.Set("username", "AReallyReallyReallyLongUsername")
 		form.Set("password", TEST_PASSWORD)
 		form.Set("returnUrl", returnURL)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 		ts.registrationShouldFail(t, rec, "Invalid username: can't be longer than 16 characters", returnURL)
 	}
@@ -349,7 +349,7 @@ func (ts *TestSuite) testRegistrationNewPlayer(t *testing.T) {
 		form.Set("username", usernameC)
 		form.Set("password", "")
 		form.Set("returnUrl", returnURL)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 		ts.registrationShouldFail(t, rec, "Invalid password: can't be blank", returnURL)
 	}
@@ -361,7 +361,7 @@ func (ts *TestSuite) testRegistrationNewPlayer(t *testing.T) {
 		form.Set("existingPlayer", "on")
 		form.Set("challengeToken", "This is not a valid challenge token.")
 		form.Set("returnUrl", returnURL)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 		ts.registrationShouldFail(t, rec, "Registration from an existing account is not allowed.", returnURL)
 	}
@@ -381,7 +381,7 @@ func (ts *TestSuite) testRegistrationNewPlayerChosenUUIDNotAllowed(t *testing.T)
 	form.Set("password", TEST_PASSWORD)
 	form.Set("uuid", uuid)
 	form.Set("returnUrl", returnURL)
-	rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+	rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 	ts.registrationShouldFail(t, rec, "Choosing a UUID is not allowed.", returnURL)
 }
@@ -398,7 +398,7 @@ func (ts *TestSuite) testRegistrationNewPlayerChosenUUID(t *testing.T) {
 		form.Set("password", TEST_PASSWORD)
 		form.Set("uuid", uuid)
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 		// Registration should succeed, grant a browserToken, and redirect to profile
 		assert.NotEqual(t, "", getCookie(rec, "browserToken"))
@@ -416,7 +416,7 @@ func (ts *TestSuite) testRegistrationNewPlayerChosenUUID(t *testing.T) {
 		form.Set("password", TEST_PASSWORD)
 		form.Set("uuid", uuid)
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 		ts.registrationShouldFail(t, rec, "That UUID is taken.", returnURL)
 	}
@@ -427,7 +427,7 @@ func (ts *TestSuite) testRegistrationNewPlayerChosenUUID(t *testing.T) {
 		form.Set("password", TEST_PASSWORD)
 		form.Set("uuid", "This is not a UUID.")
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 		ts.registrationShouldFail(t, rec, "Invalid UUID: invalid UUID length: 19", returnURL)
 	}
@@ -442,7 +442,7 @@ func (ts *TestSuite) testRegistrationNewPlayerInvite(t *testing.T) {
 		form.Set("username", usernameA)
 		form.Set("password", TEST_PASSWORD)
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Invite not found!", returnURL)
 	}
 	{
@@ -454,7 +454,7 @@ func (ts *TestSuite) testRegistrationNewPlayerInvite(t *testing.T) {
 		form.Set("password", TEST_PASSWORD)
 		form.Set("inviteCode", "invalid")
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration?invite=invalid")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Invite not found!", returnURL)
 	}
 	{
@@ -477,12 +477,12 @@ func (ts *TestSuite) testRegistrationNewPlayerInvite(t *testing.T) {
 		form.Set("password", TEST_PASSWORD)
 		form.Set("inviteCode", invite.Code)
 		form.Set("returnUrl", returnURL)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Invalid username: can't be blank", returnURL)
 
 		// Then, set a valid username and continnue
 		form.Set("username", usernameA)
-		rec = ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec = ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldSucceed(t, rec)
 
 		// Invite should be deleted
@@ -531,7 +531,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerInvite(t *testing.T) {
 		form.Set("password", TEST_PASSWORD)
 		form.Set("existingPlayer", "on")
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Invite not found!", returnURL)
 	}
 	{
@@ -544,7 +544,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerInvite(t *testing.T) {
 		form.Set("existingPlayer", "on")
 		form.Set("inviteCode", "invalid")
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration?invite=invalid")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Invite not found!", returnURL)
 	}
 	{
@@ -570,7 +570,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerInvite(t *testing.T) {
 			form.Set("existingPlayer", "on")
 			form.Set("inviteCode", invite.Code)
 			form.Set("returnUrl", returnURL)
-			rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+			rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 			ts.registrationShouldFail(t, rec, "Invalid username: can't be blank", returnURL)
 		}
 		{
@@ -582,7 +582,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerInvite(t *testing.T) {
 			form.Set("inviteCode", invite.Code)
 			form.Set("challengeToken", "This is not a valid challenge token.")
 			form.Set("returnUrl", returnURL)
-			rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+			rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 			ts.registrationShouldFail(t, rec, "Couldn't verify your skin, maybe try again: skin does not match", returnURL)
 		}
@@ -595,7 +595,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerInvite(t *testing.T) {
 			form.Set("inviteCode", invite.Code)
 			form.Set("challengeToken", challengeToken.Value)
 			form.Set("returnUrl", returnURL)
-			rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+			rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 			ts.registrationShouldSucceed(t, rec)
 
@@ -626,7 +626,7 @@ func (ts *TestSuite) testLoginLogout(t *testing.T) {
 		form.Set("username", username)
 		form.Set("password", TEST_PASSWORD)
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/login", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/login", form, nil, nil)
 		ts.loginShouldSucceed(t, rec)
 		browserTokenCookie := getCookie(rec, "browserToken")
 
@@ -645,7 +645,7 @@ func (ts *TestSuite) testLoginLogout(t *testing.T) {
 		assert.Equal(t, "", getCookie(rec, "errorMessage").Value)
 
 		// Logout should redirect to / and clear the browserToken
-		rec = ts.PostForm(ts.Server, "/drasl/logout", url.Values{}, []http.Cookie{*browserTokenCookie}, nil)
+		rec = ts.PostForm(t, ts.Server, "/drasl/logout", url.Values{}, []http.Cookie{*browserTokenCookie}, nil)
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(t, ts.App.FrontEndURL, rec.Header().Get("Location"))
 		result = ts.App.DB.First(&user, "username = ?", username)
@@ -657,7 +657,7 @@ func (ts *TestSuite) testLoginLogout(t *testing.T) {
 		form := url.Values{}
 		form.Set("username", username)
 		form.Set("password", "wrong password")
-		rec := ts.PostForm(ts.Server, "/drasl/login", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/login", form, nil, nil)
 		ts.loginShouldFail(t, rec, "Incorrect password!")
 	}
 	{
@@ -670,7 +670,7 @@ func (ts *TestSuite) testLoginLogout(t *testing.T) {
 		assert.Equal(t, "You are not logged in.", getCookie(rec, "errorMessage").Value)
 
 		// Logout without valid BrowserToken should fail
-		rec = ts.PostForm(ts.Server, "/drasl/logout", url.Values{}, nil, nil)
+		rec = ts.PostForm(t, ts.Server, "/drasl/logout", url.Values{}, nil, nil)
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(t, ts.App.FrontEndURL, rec.Header().Get("Location"))
 		assert.Equal(t, "You are not logged in.", getCookie(rec, "errorMessage").Value)
@@ -687,7 +687,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerNoVerification(t *testing.T) 
 	form.Set("password", TEST_PASSWORD)
 	form.Set("existingPlayer", "on")
 	form.Set("returnUrl", returnURL)
-	rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+	rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 	ts.registrationShouldSucceed(t, rec)
 
 	// Check that the user has been created with the same UUID
@@ -705,7 +705,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerNoVerification(t *testing.T) 
 		form.Set("username", username)
 		form.Set("password", TEST_PASSWORD)
 		form.Set("returnUrl", returnURL)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Registration without some existing account is not allowed.", returnURL)
 	}
 	{
@@ -716,7 +716,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerNoVerification(t *testing.T) 
 		form.Set("password", TEST_PASSWORD)
 		form.Set("existingPlayer", "on")
 		form.Set("returnUrl", returnURL)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Couldn't find your account, maybe try again: registration server returned error", returnURL)
 	}
 }
@@ -731,7 +731,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerWithVerification(t *testing.T
 		form.Set("password", TEST_PASSWORD)
 		form.Set("existingPlayer", "on")
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldFail(t, rec, "Couldn't verify your skin, maybe try again: player does not have a skin", returnURL)
 	}
 	{
@@ -753,7 +753,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerWithVerification(t *testing.T
 			form.Set("existingPlayer", "on")
 			form.Set("challengeToken", "This is not a valid challenge token.")
 			form.Set("returnUrl", returnURL)
-			rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+			rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 			ts.registrationShouldFail(t, rec, "Couldn't verify your skin, maybe try again: skin does not match", returnURL)
 		}
@@ -765,7 +765,7 @@ func (ts *TestSuite) testRegistrationExistingPlayerWithVerification(t *testing.T
 			form.Set("existingPlayer", "on")
 			form.Set("challengeToken", challengeToken.Value)
 			form.Set("returnUrl", returnURL)
-			rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+			rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 
 			ts.registrationShouldSucceed(t, rec)
 
@@ -797,7 +797,7 @@ func (ts *TestSuite) testNewInviteDeleteInvite(t *testing.T) {
 	returnURL := ts.App.FrontEndURL + "/drasl/admin"
 	form := url.Values{}
 	form.Set("returnUrl", returnURL)
-	rec := ts.PostForm(ts.Server, "/drasl/admin/new-invite", form, []http.Cookie{*browserTokenCookie}, nil)
+	rec := ts.PostForm(t, ts.Server, "/drasl/admin/new-invite", form, []http.Cookie{*browserTokenCookie}, nil)
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	assert.Equal(t, "", getCookie(rec, "errorMessage").Value)
@@ -813,7 +813,7 @@ func (ts *TestSuite) testNewInviteDeleteInvite(t *testing.T) {
 	form = url.Values{}
 	form.Set("inviteCode", invites[0].Code)
 	form.Set("returnUrl", returnURL)
-	rec = ts.PostForm(ts.Server, "/drasl/admin/delete-invite", form, []http.Cookie{*browserTokenCookie}, nil)
+	rec = ts.PostForm(t, ts.Server, "/drasl/admin/delete-invite", form, []http.Cookie{*browserTokenCookie}, nil)
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	assert.Equal(t, "", getCookie(rec, "errorMessage").Value)
@@ -885,7 +885,7 @@ func (ts *TestSuite) testUpdate(t *testing.T) {
 		form.Set("username", username)
 		form.Set("password", "newpassword")
 		form.Set("returnUrl", ts.App.FrontEndURL+"/drasl/registration")
-		rec = ts.PostForm(ts.Server, "/drasl/login", form, nil, nil)
+		rec = ts.PostForm(t, ts.Server, "/drasl/login", form, nil, nil)
 		ts.loginShouldSucceed(t, rec)
 		browserTokenCookie = getCookie(rec, "browserToken")
 	}
@@ -1004,7 +1004,7 @@ func (ts *TestSuite) testDeleteAccount(t *testing.T) {
 		assert.Nil(t, err)
 
 		// Delete account usernameB
-		rec := ts.PostForm(ts.Server, "/drasl/delete-user", url.Values{}, []http.Cookie{*browserTokenCookie}, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/delete-user", url.Values{}, []http.Cookie{*browserTokenCookie}, nil)
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(t, "", getCookie(rec, "errorMessage").Value)
 		assert.Equal(t, ts.App.FrontEndURL, rec.Header().Get("Location"))
@@ -1024,7 +1024,7 @@ func (ts *TestSuite) testDeleteAccount(t *testing.T) {
 		form := url.Values{}
 		form.Set("username", usernameB)
 		form.Set("password", TEST_PASSWORD)
-		rec := ts.PostForm(ts.Server, "/drasl/register", form, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/register", form, nil, nil)
 		ts.registrationShouldSucceed(t, rec)
 		browserTokenCookie := getCookie(rec, "browserToken")
 
@@ -1045,7 +1045,7 @@ func (ts *TestSuite) testDeleteAccount(t *testing.T) {
 		blueCapeHash := *UnmakeNullString(&otherUser.CapeHash)
 
 		// Delete account usernameB
-		rec = ts.PostForm(ts.Server, "/drasl/delete-user", url.Values{}, []http.Cookie{*browserTokenCookie}, nil)
+		rec = ts.PostForm(t, ts.Server, "/drasl/delete-user", url.Values{}, []http.Cookie{*browserTokenCookie}, nil)
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(t, "", getCookie(rec, "errorMessage").Value)
 		assert.Equal(t, ts.App.FrontEndURL, rec.Header().Get("Location"))
@@ -1058,7 +1058,7 @@ func (ts *TestSuite) testDeleteAccount(t *testing.T) {
 	}
 	{
 		// Delete account without valid BrowserToken should fail
-		rec := ts.PostForm(ts.Server, "/drasl/delete-user", url.Values{}, nil, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/delete-user", url.Values{}, nil, nil)
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(t, ts.App.FrontEndURL, rec.Header().Get("Location"))
 		assert.Equal(t, "You are not logged in.", getCookie(rec, "errorMessage").Value)
@@ -1087,7 +1087,7 @@ func (ts *TestSuite) testAdmin(t *testing.T) {
 		// Revoke admin from `username` should fail
 		form := url.Values{}
 		form.Set("returnUrl", returnURL)
-		rec := ts.PostForm(ts.Server, "/drasl/admin/update-users", form, []http.Cookie{*browserTokenCookie}, nil)
+		rec := ts.PostForm(t, ts.Server, "/drasl/admin/update-users", form, []http.Cookie{*browserTokenCookie}, nil)
 
 		assert.Equal(t, http.StatusSeeOther, rec.Code)
 		assert.Equal(t, "There must be at least one unlocked admin account.", getCookie(rec, "errorMessage").Value)
@@ -1100,7 +1100,7 @@ func (ts *TestSuite) testAdmin(t *testing.T) {
 	form.Set("admin-"+username, "on")
 	form.Set("admin-"+otherUsername, "on")
 	form.Set("locked-"+otherUsername, "on")
-	rec := ts.PostForm(ts.Server, "/drasl/admin/update-users", form, []http.Cookie{*browserTokenCookie}, nil)
+	rec := ts.PostForm(t, ts.Server, "/drasl/admin/update-users", form, []http.Cookie{*browserTokenCookie}, nil)
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	assert.Equal(t, "", getCookie(rec, "errorMessage").Value)
@@ -1120,7 +1120,7 @@ func (ts *TestSuite) testAdmin(t *testing.T) {
 	form = url.Values{}
 	form.Set("returnUrl", returnURL)
 	form.Set("username", otherUsername)
-	rec = ts.PostForm(ts.Server, "/drasl/delete-user", form, []http.Cookie{*browserTokenCookie}, nil)
+	rec = ts.PostForm(t, ts.Server, "/drasl/delete-user", form, []http.Cookie{*browserTokenCookie}, nil)
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	assert.Equal(t, "", getCookie(rec, "errorMessage").Value)

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=

--- a/main.go
+++ b/main.go
@@ -33,23 +33,23 @@ var bodyDump = middleware.BodyDump(func(c echo.Context, reqBody, resBody []byte)
 })
 
 type App struct {
-	FrontEndURL                 string
-	AuthURL                     string
-	AccountURL                  string
-	ServicesURL                 string
-	SessionURL                  string
-	AuthlibInjectorURL          string
-	DB                          *gorm.DB
-	FSMutex                     KeyedMutex
-	RequestCache                *ristretto.Cache
-	Config                      *Config
-	AnonymousLoginUsernameRegex *regexp.Regexp
-	Constants                   *ConstantsType
-	PlayerCertificateKeys       []SerializedKey
-	ProfilePropertyKeys         []SerializedKey
-	Key                         *rsa.PrivateKey
-	KeyB3Sum512                 []byte
-	SkinMutex                   *sync.Mutex
+	FrontEndURL            string
+	AuthURL                string
+	AccountURL             string
+	ServicesURL            string
+	SessionURL             string
+	AuthlibInjectorURL     string
+	DB                     *gorm.DB
+	FSMutex                KeyedMutex
+	RequestCache           *ristretto.Cache
+	Config                 *Config
+	TransientUsernameRegex *regexp.Regexp
+	Constants              *ConstantsType
+	PlayerCertificateKeys  []SerializedKey
+	ProfilePropertyKeys    []SerializedKey
+	Key                    *rsa.PrivateKey
+	KeyB3Sum512            []byte
+	SkinMutex              *sync.Mutex
 }
 
 func (app *App) LogError(err error, c *echo.Context) {
@@ -291,9 +291,9 @@ func setup(config *Config) *App {
 	}))
 
 	// Precompile regexes
-	var anonymousLoginUsernameRegex *regexp.Regexp
-	if config.AnonymousLogin.Allow {
-		anonymousLoginUsernameRegex = Unwrap(regexp.Compile(config.AnonymousLogin.UsernameRegex))
+	var transientUsernameRegex *regexp.Regexp
+	if config.TransientUsers.Allow {
+		transientUsernameRegex = Unwrap(regexp.Compile(config.TransientUsers.UsernameRegex))
 	}
 
 	playerCertificateKeys := make([]SerializedKey, 0, 1)
@@ -329,22 +329,22 @@ func setup(config *Config) *App {
 	}
 
 	app := &App{
-		RequestCache:                cache,
-		Config:                      config,
-		AnonymousLoginUsernameRegex: anonymousLoginUsernameRegex,
-		Constants:                   Constants,
-		DB:                          db,
-		FSMutex:                     KeyedMutex{},
-		Key:                         key,
-		KeyB3Sum512:                 keyB3Sum512,
-		FrontEndURL:                 config.BaseURL,
-		PlayerCertificateKeys:       playerCertificateKeys,
-		ProfilePropertyKeys:         profilePropertyKeys,
-		AccountURL:                  Unwrap(url.JoinPath(config.BaseURL, "account")),
-		AuthURL:                     Unwrap(url.JoinPath(config.BaseURL, "auth")),
-		ServicesURL:                 Unwrap(url.JoinPath(config.BaseURL, "services")),
-		SessionURL:                  Unwrap(url.JoinPath(config.BaseURL, "session")),
-		AuthlibInjectorURL:          Unwrap(url.JoinPath(config.BaseURL, "authlib-injector")),
+		RequestCache:           cache,
+		Config:                 config,
+		TransientUsernameRegex: transientUsernameRegex,
+		Constants:              Constants,
+		DB:                     db,
+		FSMutex:                KeyedMutex{},
+		Key:                    key,
+		KeyB3Sum512:            keyB3Sum512,
+		FrontEndURL:            config.BaseURL,
+		PlayerCertificateKeys:  playerCertificateKeys,
+		ProfilePropertyKeys:    profilePropertyKeys,
+		AccountURL:             Unwrap(url.JoinPath(config.BaseURL, "account")),
+		AuthURL:                Unwrap(url.JoinPath(config.BaseURL, "auth")),
+		ServicesURL:            Unwrap(url.JoinPath(config.BaseURL, "services")),
+		SessionURL:             Unwrap(url.JoinPath(config.BaseURL, "session")),
+		AuthlibInjectorURL:     Unwrap(url.JoinPath(config.BaseURL, "authlib-injector")),
 	}
 
 	// Post-setup

--- a/model.go
+++ b/model.go
@@ -61,8 +61,8 @@ func IDToUUID(id string) (string, error) {
 }
 
 func ValidatePlayerName(app *App, playerName string) error {
-	if AnonymousLoginEligible(app, playerName) {
-		return errors.New("name is reserved for anonymous login")
+	if TransientLoginEligible(app, playerName) {
+		return errors.New("name is reserved for transient login")
 	}
 	maxLength := app.Constants.MaxPlayerNameLength
 	if playerName == "" {
@@ -90,8 +90,7 @@ func ValidatePlayerNameOrUUID(app *App, player string) error {
 	return nil
 }
 
-func MakeAnonymousUser(app *App, playerName string) (User, error) {
-	// TODO think of a better way to do this...
+func MakeTransientUser(app *App, playerName string) (User, error) {
 	preimage := bytes.Join([][]byte{
 		[]byte("uuid"),
 		[]byte(playerName),
@@ -120,9 +119,9 @@ func MakeAnonymousUser(app *App, playerName string) (User, error) {
 	return user, nil
 }
 
-func AnonymousLoginEligible(app *App, playerName string) bool {
-	return app.Config.AnonymousLogin.Allow &&
-		app.AnonymousLoginUsernameRegex.MatchString(playerName) &&
+func TransientLoginEligible(app *App, playerName string) bool {
+	return app.Config.TransientUsers.Allow &&
+		app.TransientUsernameRegex.MatchString(playerName) &&
 		len(playerName) <= app.Constants.MaxPlayerNameLength
 }
 

--- a/services_test.go
+++ b/services_test.go
@@ -50,7 +50,7 @@ func (ts *TestSuite) testServicesProfileInformation(t *testing.T) {
 	var user User
 	assert.Nil(t, ts.App.DB.First(&user, "username = ?", TEST_USERNAME).Error)
 	{
-		rec := ts.Get(ts.Server, "/minecraft/profile", nil, &accessToken)
+		rec := ts.Get(t, ts.Server, "/minecraft/profile", nil, &accessToken)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
 		var response ServicesProfile
@@ -67,7 +67,7 @@ func (ts *TestSuite) testServicesProfileInformation(t *testing.T) {
 		assert.Nil(t, SetSkinAndSave(ts.App, &user, bytes.NewReader(RED_SKIN)))
 
 		// And try again
-		rec := ts.Get(ts.Server, "/minecraft/profile", nil, &accessToken)
+		rec := ts.Get(t, ts.Server, "/minecraft/profile", nil, &accessToken)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
 		var response ServicesProfile
@@ -89,7 +89,7 @@ func (ts *TestSuite) testPlayerAttributes(t *testing.T) {
 	accessToken := ts.authenticate(t, TEST_USERNAME, TEST_PASSWORD).AccessToken
 
 	{
-		rec := ts.Get(ts.Server, "/player/attributes", nil, &accessToken)
+		rec := ts.Get(t, ts.Server, "/player/attributes", nil, &accessToken)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
 		var response playerAttributesResponse
@@ -101,7 +101,7 @@ func (ts *TestSuite) testPlayerAttributes(t *testing.T) {
 
 	{
 		// Should fail if we send an invalid access token
-		rec := ts.Get(ts.Server, "/player/attributes", nil, Ptr("invalid"))
+		rec := ts.Get(t, ts.Server, "/player/attributes", nil, Ptr("invalid"))
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 
 		var response ErrorResponse

--- a/session.go
+++ b/session.go
@@ -69,9 +69,9 @@ func SessionHasJoined(app *App) func(c echo.Context) error {
 		var user User
 		result := app.DB.First(&user, "player_name = ?", playerName)
 		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			if app.Config.AnonymousLogin.Allow && app.AnonymousLoginUsernameRegex.MatchString(playerName) {
+			if app.Config.TransientUsers.Allow && app.TransientUsernameRegex.MatchString(playerName) {
 				var err error
-				user, err = MakeAnonymousUser(app, playerName)
+				user, err = MakeTransientUser(app, playerName)
 				if err != nil {
 					return err
 				}

--- a/session_test.go
+++ b/session_test.go
@@ -96,7 +96,7 @@ func (ts *TestSuite) testSessionHasJoined(t *testing.T) {
 		assert.Nil(t, ts.App.DB.Save(&user).Error)
 
 		url := "/session/minecraft/hasJoined?username=" + user.PlayerName + "&serverId=" + serverID + "&ip=" + "127.0.0.1"
-		rec := ts.Get(ts.Server, url, nil, nil)
+		rec := ts.Get(t, ts.Server, url, nil, nil)
 		ts.CheckAuthlibInjectorHeader(t, ts.App, rec)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -115,7 +115,7 @@ func (ts *TestSuite) testSessionHasJoined(t *testing.T) {
 		assert.Nil(t, ts.App.DB.Save(&user).Error)
 
 		url := "/session/minecraft/hasJoined?username=" + user.PlayerName + "&serverId=" + "invalid" + "&ip=" + "127.0.0.1"
-		rec := ts.Get(ts.Server, url, nil, nil)
+		rec := ts.Get(t, ts.Server, url, nil, nil)
 		ts.CheckAuthlibInjectorHeader(t, ts.App, rec)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	}
@@ -129,7 +129,7 @@ func (ts *TestSuite) testSessionProfile(t *testing.T) {
 		// Successfully get profile
 
 		url := "/session/minecraft/profile/" + Unwrap(UUIDToID(user.UUID))
-		rec := ts.Get(ts.Server, url, nil, nil)
+		rec := ts.Get(t, ts.Server, url, nil, nil)
 		ts.CheckAuthlibInjectorHeader(t, ts.App, rec)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -142,14 +142,14 @@ func (ts *TestSuite) testSessionProfile(t *testing.T) {
 	{
 		// If the UUID doesn't exist, we should get a StatusNoContent
 		url := "/session/minecraft/profile/" + "00000000000000000000000000000000"
-		rec := ts.Get(ts.Server, url, nil, nil)
+		rec := ts.Get(t, ts.Server, url, nil, nil)
 		ts.CheckAuthlibInjectorHeader(t, ts.App, rec)
 		assert.Equal(t, http.StatusNoContent, rec.Code)
 	}
 	{
 		// If the UUID is invalid, we should get a StatusBadRequest with an error message
 		url := "/session/minecraft/profile/" + "invalid"
-		rec := ts.Get(ts.Server, url, nil, nil)
+		rec := ts.Get(t, ts.Server, url, nil, nil)
 		ts.CheckAuthlibInjectorHeader(t, ts.App, rec)
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 
@@ -160,6 +160,6 @@ func (ts *TestSuite) testSessionProfile(t *testing.T) {
 }
 
 func (ts *TestSuite) testSessionBlockedServers(t *testing.T) {
-	rec := ts.Get(ts.Server, "/blockedservers", nil, nil)
+	rec := ts.Get(t, ts.Server, "/blockedservers", nil, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }


### PR DESCRIPTION
Originally I worked on this in the hope of making `TransientUsers` stateless on the server side, or at least make it so transient logins don't hit the database. That doesn't seem feasible; we will always need to resolve a UUID to a transient user player name, and that means we need to store a mapping of UUID -> player name somehow. There just aren't enough bits in a UUID to encode both (1) a player name and (2) some kind of magic number to mark that the UUID is for a transient user.

But JWTs are still good to have because:

- They use less serverside state than storing every access token for every user
  - Although we need to invalidate tokens, so we still at least need to store a "token version" in the DB
- Mojang and other auth servers (Ely.by, Blessing Skin AFAICT) also use JWTs

Auto-migrating from the old database schema needs to be tested. At the very least, all client sessions will be invalidated. Make a backup of your drasl.db before testing!