### PR TITLE
authlib-injector: set feature.enable_profile_key

### DIFF
--- a/authlib_injector.go
+++ b/authlib_injector.go
@@ -10,16 +10,17 @@ import (
 	"net/url"
 )
 
-type authlibInjectorMeta struct {
-	ImplementationName    string               `json:"implementationName"`
-	ImplementationVersion string               `json:"implementationVersion"`
-	Links                 authlibInjectorLinks `json:"links"`
-	ServerName            string               `json:"serverName"`
-}
-
 type authlibInjectorLinks struct {
 	Homepage string `json:"homepage"`
 	Register string `json:"register"`
+}
+
+type authlibInjectorMeta struct {
+	ImplementationName      string               `json:"implementationName"`
+	ImplementationVersion   string               `json:"implementationVersion"`
+	Links                   authlibInjectorLinks `json:"links"`
+	ServerName              string               `json:"serverName"`
+	FeatureEnableProfileKey bool                 `json:"feature.enable_profile_key"`
 }
 
 type authlibInjectorResponse struct {
@@ -70,7 +71,8 @@ func AuthlibInjectorRoot(app *App) func(c echo.Context) error {
 				Homepage: app.FrontEndURL,
 				Register: Unwrap(url.JoinPath(app.FrontEndURL, "drasl/registration")),
 			},
-			ServerName: app.Config.InstanceName,
+			ServerName:              app.Config.InstanceName,
+			FeatureEnableProfileKey: true,
 		},
 		SignaturePublickey:  signaturePublicKey,
 		SignaturePublickeys: signaturePublicKeys,


### PR DESCRIPTION
Per the authlib-injector docs [0], authlib-injector will not fetch player certificates unless `feature.enable_profile_key` is set.

Resolves https://github.com/unmojang/drasl/issues/40

I'm not totally sure why we need this `feature` flag when using HMCL but not when using PollyMC.

[0] https://github-com.translate.goog/yushijinhun/authlib-injector/wiki/Yggdrasil-%E6%9C%8D%E5%8A%A1%E7%AB%AF%E6%8A%80%E6%9C%AF%E8%A7%84%E8%8C%83?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en#%E5%8A%9F%E8%83%BD%E9%80%89%E9%A1%B9,