### PR TITLE
made admins able to bypass AllowChangingPlayerName, AllowSkins and AllowCapes

### DIFF
--- a/front.go
+++ b/front.go
@@ -530,7 +530,7 @@ func FrontUpdate(app *App) func(c echo.Context) error {
 				setErrorMessage(&c, fmt.Sprintf("Invalid player name: %s", err))
 				return c.Redirect(http.StatusSeeOther, returnURL)
 			}
-			if !app.Config.AllowChangingPlayerName {
+			if !app.Config.AllowChangingPlayerName && !user.IsAdmin {
 				setErrorMessage(&c, "Changing your player name is not allowed.")
 				return c.Redirect(http.StatusSeeOther, returnURL)
 			}
@@ -608,7 +608,7 @@ func FrontUpdate(app *App) func(c echo.Context) error {
 
 		if skinFileErr == nil || skinURL != "" {
 			// The user is setting a new skin
-			if !app.Config.AllowSkins {
+			if !app.Config.AllowSkins && !user.IsAdmin {
 				setErrorMessage(&c, "Setting a skin is not allowed.")
 				return c.Redirect(http.StatusSeeOther, returnURL)
 			}
@@ -656,7 +656,7 @@ func FrontUpdate(app *App) func(c echo.Context) error {
 		oldCapeHash := UnmakeNullString(&profileUser.CapeHash)
 
 		if capeFileErr == nil || capeURL != "" {
-			if !app.Config.AllowCapes {
+			if !app.Config.AllowCapes && !user.IsAdmin {
 				setErrorMessage(&c, "Setting a cape is not allowed.")
 				return c.Redirect(http.StatusSeeOther, returnURL)
 			}
@@ -690,9 +690,9 @@ func FrontUpdate(app *App) func(c echo.Context) error {
 			if err != nil {
 				return err
 			}
-			user.CapeHash = MakeNullString(&hash)
+			profileUser.CapeHash = MakeNullString(&hash)
 		} else if deleteCape {
-			user.CapeHash = MakeNullString(nil)
+			profileUser.CapeHash = MakeNullString(nil)
 		}
 
 		newSkinHash := UnmakeNullString(&profileUser.SkinHash)

--- a/view/profile.tmpl
+++ b/view/profile.tmpl
@@ -23,7 +23,7 @@
     method="post"
     enctype="multipart/form-data"
   >
-    {{ if .App.Config.AllowChangingPlayerName }}
+    {{ if or .App.Config.AllowChangingPlayerName .User.IsAdmin }}
       <p>
         <label for="player-name"
           >Player Name (can be different from username)</label
@@ -331,7 +331,7 @@
         </option>
       </select>
     </p>
-    {{ if .App.Config.AllowSkins }}
+    {{ if or .App.Config.AllowSkins .User.IsAdmin }}
       <h4>Skin</h4>
       <p>
         <label for="skin-url">URL to skin file</label><br />
@@ -373,7 +373,7 @@
         <label for="skin-model-slim">Slim</label>
       </fieldset>
     {{ end }}
-    {{ if .App.Config.AllowCapes }}
+    {{ if or .App.Config.AllowCapes .User.IsAdmin }}
       <h4>Cape</h4>
       <p>
         <label for="cape-url">URL to cape file</label><br />


### PR DESCRIPTION
Closes #45

I made admins able to bypass AllowChangingPlayerName, AllowSkins and AllowCapes.

I've never used Go before, but it all seems to work as intended.

EDIT:
This has also solved an existing problem, which was that admins could not change the cape of others even if AllowCapes was set to true because `user` was specified in the cape method instead of `profileUser`