### PR TITLE
Add `minecraft/profile/lookup/bulk/byname` alias

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -23,7 +23,7 @@ func TestAccount(t *testing.T) {
 		ts.CreateTestUser(ts.Server, TEST_USERNAME)
 
 		t.Run("Test /users/profiles/minecraft/:playerName", ts.testAccountPlayerNameToID)
-		t.Run("Test /profiles/minecraft", ts.testAccountPlayerNamesToIDs)
+		t.Run("Test /profiles/minecraft", ts.makeTestAccountPlayerNamesToIDs("/profiles/minecraft"))
 	}
 	{
 		ts := &TestSuite{}
@@ -68,30 +68,6 @@ func (ts *TestSuite) testAccountPlayerNameToID(t *testing.T) {
 	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
 	uuid, err = IDToUUID(response.ID)
 	assert.Equal(t, user.UUID, uuid)
-}
-
-func (ts *TestSuite) testAccountPlayerNamesToIDs(t *testing.T) {
-	payload := []string{TEST_USERNAME, "nonexistent"}
-	body, err := json.Marshal(payload)
-	assert.Nil(t, err)
-
-	req := httptest.NewRequest(http.MethodPost, "/profiles/minecraft", bytes.NewBuffer(body))
-	rec := httptest.NewRecorder()
-	ts.Server.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var response []playerNameToUUIDResponse
-	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
-
-	// Get the real UUID
-	var user User
-	result := ts.App.DB.First(&user, "username = ?", TEST_USERNAME)
-	assert.Nil(t, result.Error)
-	id, err := UUIDToID(user.UUID)
-	assert.Nil(t, err)
-
-	// There should only be one user, the nonexistent user should not be present
-	assert.Equal(t, []playerNameToUUIDResponse{{Name: TEST_USERNAME, ID: id}}, response)
 }
 
 func (ts *TestSuite) testAccountPlayerNameToIDFallback(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -251,6 +251,7 @@ func GetServer(app *App) *echo.Echo {
 	e.POST("/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/publickeys", servicesPublicKeys)
+	e.POST("/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
 	e.GET("/services/player/attributes", servicesPlayerAttributes)
 	e.POST("/services/player/certificates", servicesPlayerCertificates)
@@ -264,6 +265,7 @@ func GetServer(app *App) *echo.Echo {
 	e.POST("/services/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/services/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/services/publickeys", servicesPublicKeys)
+	e.POST("/services/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
 	return e
 }


### PR DESCRIPTION
As of 23w42a, the "Usernames to UUIDs" endpoint, previously at POST https://api.mojang.com/profiles/minecraft, has been moved to POST https://api.minecraftservices.com/minecraft/profile/lookup/bulk/byname.

This patch adds an alias for the new endpoint. The old endpoint will still work.

Related: https://github.com/yushijinhun/authlib-injector/issues/232