### PR TITLE
systemd service should call /usr/local/bin/drasl

### DIFF
--- a/example/drasl.service
+++ b/example/drasl.service
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 DynamicUser=true
-ExecStart=/usr/bin/drasl
+ExecStart=/usr/local/bin/drasl
 StateDirectory=drasl
 Restart=always
 


### PR DESCRIPTION
The average consumer of this is someone installing Drasl via `make install`, following the instructions in installation.md. Downstream packagers will know to change this to /usr/bin/drasl.

Resolves https://github.com/unmojang/drasl/issues/48.