### PR TITLE
Fix docker-caddy example

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -17,7 +17,7 @@ Other available options:
 - `ApplicationOwner`: you or your organization's name. String. Default value: `"Anonymous"`.
 - `StateDirectory`: directory to store application state, including the database (`drasl.db`), skins, and capes. String. Default value: `"/var/lib/drasl/"`.
 - `DataDirectory`: directory where Drasl's static assets are installed. String. Default value: `"/usr/share/drasl"`.
-- `ListenAddress`: IP address and port to listen on. You probably want to change this to `"127.0.0.1:25585"` if you run your reverse proxy server on the same host. String. Default value: `"0.0.0.0:25585"`.
+- `ListenAddress`: IP address and port to listen on. Depending on how you configure your reverse proxy and whether you run Drasl in a container, you should consider setting the listen address to `"127.0.0.1:25585"` to ensure Drasl is only accessible through the reverse proxy. If your reverse proxy is unable to connect to Drasl, try setting this back to the default value. String. Default value: `"0.0.0.0:25585"`.
 - `DefaultAdmins`: Usernames of the instance's permanent admins. Admin rights can be granted to other accounts using the web UI, but admins defined via `DefaultAdmins` cannot be demoted unless they are removed from the config file. Array of strings. Default value: `[]`.
 - `[RateLimit]`: Rate-limit requests per IP address to limit abuse. Only applies to certain web UI routes, not any Yggdrasil routes. Requests for skins, capes, and web pages are also unaffected. Uses [Echo](https://echo.labstack.com)'s [rate limiter middleware](https://echo.labstack.com/middleware/rate-limiter/).
   - `Enable`: Boolean. Default value: `true`.

--- a/example/docker-caddy/Caddyfile
+++ b/example/docker-caddy/Caddyfile
@@ -4,4 +4,6 @@ drasl.example.com
 # Email address to use for obtaining TLS certificates
 tls mail@example.com
 
-reverse_proxy :25585
+# In this instance, `drasl` is the name of the Drasl container, specified in
+# docker-compose.yaml.
+reverse_proxy drasl:25585

--- a/example/docker-caddy/docker-compose.yaml
+++ b/example/docker-caddy/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   caddy:
     image: caddy
@@ -12,8 +10,6 @@ services:
       - ./caddy/config:/config
   drasl:
     image: unmojang/drasl
-    ports:
-      - "127.0.0.1:25585:25585"
     volumes:
       - ./config:/etc/drasl
       - ./data:/var/lib/drasl


### PR DESCRIPTION
The Caddy container couldn't access the Drasl container unless using `net=host`. Also remove the :25585 port mapping in docker-compose.yaml, they're no longer needed, and the "version" field, it's obsolete now.

May resolve https://github.com/unmojang/drasl/issues/60