### PR TITLE
auth: Fix client version not getting persisted

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -161,7 +161,8 @@ func AuthAuthenticate(app *App) func(c echo.Context) error {
 			}
 		}
 
-		result = app.DB.Save(&user)
+		// Save changes to user.Clients
+		result = app.DB.Session(&gorm.Session{FullSaveAssociations: true}).Save(&user)
 		if result.Error != nil {
 			return result.Error
 		}


### PR DESCRIPTION
Gorm won't save changes to associated objects unless you use a `gorm.Session` with `FullSaveAssociations: true`.

Fixes a serious bug where clients can't `POST /authenticate` with an existing `clientToken`, they can only `refresh`.