### PR TITLE
Allow duplicate client tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-prefix ?= /usr/local
+prefix ?= /usr
 .DEFAULT_GOAL := build
 
 prebuild:

--- a/auth.go
+++ b/auth.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 	"net/http"
@@ -132,6 +133,7 @@ func AuthAuthenticate(app *App) func(c echo.Context) error {
 				return err
 			}
 			client = Client{
+				UUID:        uuid.New().String(),
 				ClientToken: clientToken,
 				Version:     0,
 			}
@@ -154,6 +156,7 @@ func AuthAuthenticate(app *App) func(c echo.Context) error {
 
 			if !clientExists {
 				client = Client{
+					UUID:        uuid.New().String(),
 					ClientToken: clientToken,
 					Version:     0,
 				}

--- a/auth_test.go
+++ b/auth_test.go
@@ -16,6 +16,7 @@ func TestAuth(t *testing.T) {
 		defer ts.Teardown()
 
 		ts.CreateTestUser(ts.Server, TEST_USERNAME)
+		ts.CreateTestUser(ts.Server, TEST_OTHER_USERNAME)
 
 		t.Run("Test /", ts.testGetServerInfo)
 		t.Run("Test /authenticate", ts.testAuthenticate)
@@ -23,6 +24,8 @@ func TestAuth(t *testing.T) {
 		t.Run("Test /refresh", ts.testRefresh)
 		t.Run("Test /signout", ts.testSignout)
 		t.Run("Test /validate", ts.testValidate)
+
+		t.Run("Test authenticate with duplicate client token", ts.testDuplicateClientToken)
 	}
 }
 
@@ -453,4 +456,42 @@ func (ts *TestSuite) testValidate(t *testing.T) {
 		rec := ts.PostJSON(t, ts.Server, "/validate", payload, nil, nil)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	}
+}
+
+func (ts *TestSuite) testDuplicateClientToken(t *testing.T) {
+	// Two users should be able to use the same clientToken
+
+	authenticateRes := ts.authenticate(t, TEST_USERNAME, TEST_PASSWORD)
+	clientToken := authenticateRes.ClientToken
+
+	payload := authenticateRequest{
+		Username:    TEST_OTHER_USERNAME,
+		Password:    TEST_PASSWORD,
+		ClientToken: &clientToken,
+		RequestUser: false,
+	}
+	rec := ts.PostJSON(t, ts.Server, "/authenticate", payload, nil, nil)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var response authenticateResponse
+	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
+	assert.Equal(t, clientToken, response.ClientToken)
+
+	var user User
+	result := ts.App.DB.First(&user, "username = ?", TEST_USERNAME)
+	assert.Nil(t, result.Error)
+
+	var otherUser User
+	result = ts.App.DB.First(&otherUser, "username = ?", TEST_OTHER_USERNAME)
+	assert.Nil(t, result.Error)
+
+	var client Client
+	result = ts.App.DB.Preload("User").First(&client, "client_token = ? AND user_uuid = ?", clientToken, user.UUID)
+	assert.Nil(t, result.Error)
+	assert.Equal(t, TEST_USERNAME, client.User.Username)
+
+	var otherClient Client
+	result = ts.App.DB.Preload("User").First(&otherClient, "client_token = ? AND user_uuid = ?", clientToken, otherUser.UUID)
+	assert.Nil(t, result.Error)
+	assert.Equal(t, TEST_OTHER_USERNAME, otherClient.User.Username)
 }

--- a/example/drasl.service
+++ b/example/drasl.service
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 DynamicUser=true
-ExecStart=/usr/local/bin/drasl
+ExecStart=/usr/bin/drasl
 StateDirectory=drasl
 Restart=always
 

--- a/test_suite_test.go
+++ b/test_suite_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 const TEST_USERNAME = "username"
+const TEST_OTHER_USERNAME = "otherUsername"
 const TEST_USERNAME_UPPERCASE = "USERNAME"
 const TEST_PASSWORD = "password"
 


### PR DESCRIPTION
Allow multiple users to use the same client token without interfering with each other.

This change bumps the SQL database version from 1 to 2 and introduces a migration step.

For https://github.com/unmojang/drasl/issues/53.