### PR TITLE
Use accent-color, not feColorMatrix

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -108,7 +108,7 @@ input[type="password"] {
 
 input[type="checkbox"],
 input[type="radio"] {
-  filter: url("#filter");
+  accent-color: var(--accent);
 }
 
 input[type="checkbox"]:not(:disabled),

--- a/view/layout.tmpl
+++ b/view/layout.tmpl
@@ -23,22 +23,11 @@
     <body>
       <div id="background"></div>
       <main id="content">{{ block "content" . }}{{ end }}</main>
-      <svg xmlns="http://www.w3.org/2000/svg" class="svg-defs">
-        <filter id="filter">
-          <feColorMatrix
-            type="matrix"
-            values=" 0.000  0.000  0.000  0.000  0.000
-			      -0.200 -0.200 -0.200  0.000  0.400
-			      -0.200 -0.200 -0.200  0.000  0.400
-			       0.000  0.000  0.000  1.000  0.000"
-          ></feColorMatrix>
-        </filter>
-      </svg>
       {{ if .App.Config.EnableBackgroundEffect }}
-    <script type="module">
-      import { background } from "{{.App.FrontEndURL}}/drasl/public/bundle.js";
-      background(document.querySelector("#background"));
-    </script>
+      <script type="module">
+        import { background } from "{{.App.FrontEndURL}}/drasl/public/bundle.js";
+        background(document.querySelector("#background"));
+      </script>
       {{ end }}
     </body>
   </html>


### PR DESCRIPTION
The `accent-color` CSS property now has pretty good support: https://caniuse.com/mdn-css_properties_accent-color, so we should use it instead of coloring radios/checkboxes with an SVG filter hack.