### PR TITLE
Add legacy endpoint for 1.16.5 and its derivates.

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,6 +255,7 @@ func GetServer(app *App) *echo.Echo {
 	e.GET("/publickeys", servicesPublicKeys)
 	e.POST("/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
+	e.GET("/services/privileges", servicesPlayerAttributes)
 	e.GET("/services/player/attributes", servicesPlayerAttributes)
 	e.POST("/services/player/certificates", servicesPlayerCertificates)
 	e.DELETE("/services/minecraft/profile/capes/active", servicesDeleteCape)

--- a/main.go
+++ b/main.go
@@ -240,6 +240,7 @@ func GetServer(app *App) *echo.Echo {
 	servicesChangeName := ServicesChangeName(app)
 	servicesPublicKeys := ServicesPublicKeys(app)
 
+	e.GET("/privileges", servicesPlayerAttributes)
 	e.GET("/player/attributes", servicesPlayerAttributes)
 	e.POST("/player/certificates", servicesPlayerCertificates)
 	e.DELETE("/minecraft/profile/capes/active", servicesDeleteCape)


### PR DESCRIPTION
Looks like 1.16.5 not uses standard endpoint which others version use, however its literally same thing as other versions use so i decided simply add the route in main.go.