### PR TITLE
Implement joinserver.jsp and checkserver.jsp

### DIFF
--- a/account.go
+++ b/account.go
@@ -125,7 +125,7 @@ func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 			}
 
 			payload := make([]string, 0, len(remainingPlayers))
-			for remainingPlayer, _ := range remainingPlayers {
+			for remainingPlayer := range remainingPlayers {
 				payload = append(payload, remainingPlayer)
 			}
 			body, err := json.Marshal(payload)

--- a/api.go
+++ b/api.go
@@ -349,7 +349,7 @@ func (app *App) APICreateUser() func(c echo.Context) error {
 }
 
 type APIUpdateUserRequest struct {
-	Password          *string `json:"password" example"hunter2"`         // Optional. New plaintext password
+	Password          *string `json:"password" example:"hunter2"`        // Optional. New plaintext password
 	IsAdmin           *bool   `json:"isAdmin" example:"true"`            // Optional. Pass`true` to grant, `false` to revoke admin privileges.
 	IsLocked          *bool   `json:"isLocked" example:"false"`          // Optional. Pass `true` to lock (disable), `false` to unlock user.
 	PlayerName        *string `json:"playerName" example:"MyPlayerName"` // Optional. New player name. Can be different from the user's username.

--- a/main.go
+++ b/main.go
@@ -219,16 +219,22 @@ func (app *App) MakeServer() *echo.Echo {
 
 	// Session
 	sessionHasJoined := SessionHasJoined(app)
+	sessionCheckServer := SessionCheckServer(app)
 	sessionJoin := SessionJoin(app)
+	sessionJoinServer := SessionJoinServer(app)
 	sessionProfile := SessionProfile(app)
 	sessionBlockedServers := SessionBlockedServers(app)
 	e.GET("/session/minecraft/hasJoined", sessionHasJoined)
+	e.GET("/game/checkserver.jsp", sessionCheckServer)
 	e.POST("/session/minecraft/join", sessionJoin)
+	e.GET("/game/joinserver.jsp", sessionJoinServer)
 	e.GET("/session/minecraft/profile/:id", sessionProfile)
 	e.GET("/blockedservers", sessionBlockedServers)
 
 	e.GET("/session/session/minecraft/hasJoined", sessionHasJoined)
+	e.GET("/session/game/checkserver.jsp", sessionCheckServer)
 	e.POST("/session/session/minecraft/join", sessionJoin)
+	e.GET("/session/game/joinserver.jsp", sessionJoinServer)
 	e.GET("/session/session/minecraft/profile/:id", sessionProfile)
 	e.GET("/session/blockedservers", sessionBlockedServers)
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func (app *App) HandleError(err error, c echo.Context) {
 		// Web front end
 		additionalErr = app.HandleWebError(err, &c)
 	}
-	if err != nil {
+	if additionalErr != nil {
 		app.LogError(fmt.Errorf("Additional error while handling an error: %w", additionalErr), &c)
 	}
 }

--- a/session.go
+++ b/session.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type sessionJoinRequest struct {
@@ -41,6 +42,60 @@ func SessionJoin(app *App) func(c echo.Context) error {
 	}
 }
 
+// /game/joinserver.jsp
+func SessionJoinServer(app *App) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		username := c.QueryParam("user")
+		sessionID := c.QueryParam("sessionId")
+		serverID := c.QueryParam("serverId")
+
+		// If any parameters are missing, return NO
+		if username == "" || sessionID == "" || serverID == "" {
+			return c.String(http.StatusOK, "Bad login")
+
+		}
+
+		// Parse sessionId. It has the form:
+		// token:<accessToken>:<player UUID>
+		split := strings.Split(sessionID, ":")
+		if len(split) != 3 || split[0] != "token" {
+			return c.String(http.StatusOK, "Bad login")
+		}
+		accessToken := split[1]
+		id := split[2]
+
+		// Is the accessToken valid?
+		client := app.GetClient(accessToken, StalePolicyDeny)
+		if client == nil {
+			return c.String(http.StatusOK, "Bad login")
+		}
+
+		// If the player name corresponding to the access token doesn't match
+		// the `user` param from the request, return NO
+		user := client.User
+		if user.PlayerName != username {
+			return c.String(http.StatusOK, "Bad login")
+		}
+		// If the player's UUID doesn't match the UUID in the sessionId, return
+		// NO
+		userID, err := UUIDToID(user.UUID)
+		if err != nil {
+			return err
+		}
+		if userID != id {
+			return c.String(http.StatusOK, "Bad login")
+		}
+
+		user.ServerID = MakeNullString(&serverID)
+		result := app.DB.Save(&user)
+		if result.Error != nil {
+			return result.Error
+		}
+
+		return c.String(http.StatusOK, "OK")
+	}
+}
+
 func fullProfile(app *App, user *User, uuid string, sign bool) (SessionProfileResponse, error) {
 	id, err := UUIDToID(uuid)
 	if err != nil {
@@ -59,67 +114,84 @@ func fullProfile(app *App, user *User, uuid string, sign bool) (SessionProfileRe
 	}, nil
 }
 
+func (app *App) hasJoined(c *echo.Context, playerName string, serverID string, legacy bool) error {
+	var user User
+	result := app.DB.First(&user, "player_name = ?", playerName)
+	// If the error isn't "not found", throw.
+	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return result.Error
+	}
+
+	if result.Error != nil || !user.ServerID.Valid || serverID != user.ServerID.String {
+		for _, fallbackAPIServer := range app.Config.FallbackAPIServers {
+			if fallbackAPIServer.DenyUnknownUsers && result.Error != nil {
+				// If DenyUnknownUsers is enabled and the player name is
+				// not known, don't query the fallback server.
+				continue
+			}
+			base, err := url.Parse(fallbackAPIServer.SessionURL)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+
+			base.Path += "/session/minecraft/hasJoined"
+			params := url.Values{}
+			params.Add("username", playerName)
+			params.Add("serverId", serverID)
+			base.RawQuery = params.Encode()
+
+			res, err := MakeHTTPClient().Get(base.String())
+			if err != nil {
+				log.Printf("Received invalid response from fallback API server at %s\n", base.String())
+				continue
+			}
+			defer res.Body.Close()
+
+			if res.StatusCode == http.StatusOK {
+				if legacy {
+					return (*c).String(http.StatusOK, "YES")
+				} else {
+					return (*c).Stream(http.StatusOK, res.Header.Get("Content-Type"), res.Body)
+				}
+			}
+		}
+
+		if legacy {
+			return (*c).String(http.StatusMethodNotAllowed, "NO")
+		} else {
+			return (*c).NoContent(http.StatusForbidden)
+		}
+	}
+
+	if legacy {
+		return (*c).String(http.StatusOK, "YES")
+	}
+
+	profile, err := fullProfile(app, &user, user.UUID, true)
+	if err != nil {
+		return err
+	}
+
+	return (*c).JSON(http.StatusOK, profile)
+}
+
 // /session/minecraft/hasJoined
 // https://c4k3.github.io/wiki.vg/Protocol_Encryption.html#Server
 func SessionHasJoined(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		playerName := c.QueryParam("username")
 		serverID := c.QueryParam("serverId")
+		return app.hasJoined(&c, playerName, serverID, false)
+	}
+}
 
-		var user User
-		result := app.DB.First(&user, "player_name = ?", playerName)
-		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			if app.Config.TransientUsers.Allow && app.TransientUsernameRegex.MatchString(playerName) {
-				var err error
-				user, err = MakeTransientUser(app, playerName)
-				if err != nil {
-					return err
-				}
-			} else {
-				return c.NoContent(http.StatusForbidden)
-			}
-		}
-
-		if result.Error != nil || !user.ServerID.Valid || serverID != user.ServerID.String {
-			for _, fallbackAPIServer := range app.Config.FallbackAPIServers {
-				if fallbackAPIServer.DenyUnknownUsers && result.Error != nil {
-					// If DenyUnknownUsers is enabled and the player name is
-					// not known, don't query the fallback server.
-					continue
-				}
-				base, err := url.Parse(fallbackAPIServer.SessionURL)
-				if err != nil {
-					log.Println(err)
-					continue
-				}
-
-				base.Path += "/session/minecraft/hasJoined"
-				params := url.Values{}
-				params.Add("username", playerName)
-				params.Add("serverId", serverID)
-				base.RawQuery = params.Encode()
-
-				res, err := MakeHTTPClient().Get(base.String())
-				if err != nil {
-					log.Printf("Received invalid response from fallback API server at %s\n", base.String())
-					continue
-				}
-				defer res.Body.Close()
-
-				if res.StatusCode == http.StatusOK {
-					return c.Stream(http.StatusOK, res.Header.Get("Content-Type"), res.Body)
-				}
-			}
-
-			return c.NoContent(http.StatusForbidden)
-		}
-
-		profile, err := fullProfile(app, &user, user.UUID, true)
-		if err != nil {
-			return err
-		}
-
-		return c.JSON(http.StatusOK, profile)
+// /game/checkserver.jsp
+func SessionCheckServer(app *App) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		playerName := c.QueryParam("user")
+		serverID := c.QueryParam("serverId")
+		return app.hasJoined(&c, playerName, serverID, true)
 	}
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -716,7 +716,8 @@
                 },
                 "password": {
                     "description": "Optional. New plaintext password",
-                    "type": "string"
+                    "type": "string",
+                    "example": "hunter2"
                 },
                 "playerName": {
                     "description": "Optional. New player name. Can be different from the user's username.",

--- a/util.go
+++ b/util.go
@@ -51,6 +51,12 @@ func Contains[T comparable](slice []T, target T) bool {
 	return false
 }
 
+func SliceRemove[T any](slice []T, index int) []T {
+	ret := make([]T, 0)
+	ret = append(ret, slice[:index]...)
+	return append(ret, slice[index+1:]...)
+}
+
 func ContainsPublicKey(slice []rsa.PublicKey, target *rsa.PublicKey) bool {
 	for _, el := range slice {
 		if el.Equal(target) {

--- a/util.go
+++ b/util.go
@@ -51,12 +51,6 @@ func Contains[T comparable](slice []T, target T) bool {
 	return false
 }
 
-func SliceRemove[T any](slice []T, index int) []T {
-	ret := make([]T, 0)
-	ret = append(ret, slice[:index]...)
-	return append(ret, slice[index+1:]...)
-}
-
 func ContainsPublicKey(slice []rsa.PublicKey, target *rsa.PublicKey) bool {
 	for _, el := range slice {
 		if el.Equal(target) {


### PR DESCRIPTION
For https://github.com/unmojang/drasl/issues/52, if we end up adding support for old versions via an HTTP proxy or similar.

We may not need this since patching the game to use the new routes might be a better/simpler solution. For example, if we add support for the `-Dminecraft.api.*.host` system properties to https://github.com/betacraftuk/legacyfix and integrate it nicely into Fjord Launcher, Ely.by and Blessing Skin accounts would "just work" on old versions without those auth servers needing to implement the legacy API routes.

An HTTP proxy like betacraft.uk uses also has the drawback that all traffic will be proxied. There doesn't seem to be a way to tell (ancient) Java to only proxy certain domains (I stand to be corrected), so some mods might break if they make requests to other URLs that Drasl doesn't respond to. We could have a configurable option to proxy all requests, but that'd be dangerous.