### PR TITLE
GHA: use docker/setup-qemu-action to install qemu

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -13,9 +13,7 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           extra_nix_config: |
             extra-platforms = aarch64-linux
-      - run: |
-          DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
+      - uses: docker/setup-qemu-action@v3
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build
       - run: nix flake check


### PR DESCRIPTION
Fixes

```
Package qemu-efi is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
```