### PR TITLE
Update wiki.vg links to minecraft.wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ See [doc/usage.md](doc/usage.md) for post-installation instructions and guidance
 
 Drasl has its own API for managing users and invitations, but consider it in a beta state. v1 of this API is likely to be deprecated quickly. Documentation is [here](https://doc.drasl.unmojang.org).
 
-Drasl implements the Mojang API, documented here on [wiki.vg](https://wiki.vg):
+Drasl implements the Mojang API, documented here on [The Minecraft Wiki](https://minecraft.wiki):
 
-- [Mojang API](https://wiki.vg/Mojang_API)
-- [Legacy Mojang Authentication](https://wiki.vg/Legacy_Mojang_Authentication)
-- [Protocol Encryption](https://wiki.vg/Protocol_Encryption)
+- [Mojang API](https://minecraft.wiki/w/Mojang_API)
+- [Yggdrasil](https://minecraft.wiki/w/Yggdrasil)
+- [Protocol Encryption](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol_Encryption)
 
 If you find that an API route behaves substantively different than the Mojang API, please [file an issue](https://github.com/unmojang/drasl/issues).
 

--- a/account.go
+++ b/account.go
@@ -18,7 +18,7 @@ type playerNameToUUIDResponse struct {
 }
 
 // GET /users/profiles/minecraft/:playerName
-// https://wiki.vg/Mojang_API#Username_to_UUID
+// https://minecraft.wiki/w/Mojang_API#Query_player's_UUID
 func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		playerName := c.Param("playerName")
@@ -80,7 +80,7 @@ func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 
 // POST /profiles/minecraft
 // POST /minecraft/profile/lookup/bulk/byname
-// https://wiki.vg/Mojang_API#Usernames_to_UUIDs
+// https://minecraft.wiki/w/Mojang_API#Query_player_UUIDs_in_batch
 func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		var playerNames []string
@@ -169,7 +169,6 @@ func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 }
 
 // GET /user/security/location
-// https://wiki.vg/Mojang_API#Verify_Security_Location
 func AccountVerifySecurityLocation(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)

--- a/auth.go
+++ b/auth.go
@@ -95,7 +95,7 @@ type authenticateResponse struct {
 }
 
 // POST /authenticate
-// https://wiki.vg/Legacy_Mojang_Authentication#Authenticate
+// https://minecraft.wiki/w/Yggdrasil#Authenticate
 func AuthAuthenticate(app *App) func(c echo.Context) error {
 	return func(c echo.Context) (err error) {
 		req := new(authenticateRequest)
@@ -257,7 +257,7 @@ type refreshResponse struct {
 }
 
 // POST /refresh
-// https://wiki.vg/Legacy_Mojang_Authentication#Refresh
+// https://minecraft.wiki/w/Yggdrasil#Refresh
 func AuthRefresh(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(refreshRequest)
@@ -348,7 +348,7 @@ type validateRequest struct {
 }
 
 // POST /validate
-// https://wiki.vg/Legacy_Mojang_Authentication#Validate
+// https://minecraft.wiki/w/Yggdrasil#Validate
 func AuthValidate(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(validateRequest)
@@ -371,7 +371,7 @@ type signoutRequest struct {
 }
 
 // POST /signout
-// https://wiki.vg/Legacy_Mojang_Authentication#Signout
+// https://minecraft.wiki/w/Yggdrasil#Signout
 func AuthSignout(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(signoutRequest)
@@ -409,7 +409,7 @@ type invalidateRequest struct {
 }
 
 // POST /invalidate
-// https://wiki.vg/Legacy_Mojang_Authentication#Invalidate
+// https://minecraft.wiki/w/Yggdrasil#Invalidate
 func AuthInvalidate(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(invalidateRequest)

--- a/services.go
+++ b/services.go
@@ -60,7 +60,7 @@ type ServicesProfile struct {
 	ID    string                `json:"id"`
 	Name  string                `json:"name"`
 	Skins []ServicesProfileSkin `json:"skins"`
-	Capes []string              `json:"capes"` // TODO implement capes, they are undocumented on https://wiki.vg/Mojang_API#Profile_Information
+	Capes []string              `json:"capes"` // TODO implement capes, they are documented at https://minecraft.wiki/w/Mojang_API#Query_player_profile
 }
 
 func getServicesProfile(app *App, player *Player) (ServicesProfile, error) {
@@ -125,7 +125,7 @@ func getServicesProfile(app *App, player *Player) (ServicesProfile, error) {
 }
 
 // GET /minecraft/profile
-// https://wiki.vg/Mojang_API#Profile_Information
+// https://minecraft.wiki/w/Mojang_API#Query_player_profile
 func ServicesProfileInformation(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		servicesProfile, err := getServicesProfile(app, player)
@@ -160,7 +160,7 @@ type playerAttributesResponse struct {
 }
 
 // GET /player/attributes
-// https://wiki.vg/Mojang_API#Player_Attributes
+// https://minecraft.wiki/w/Mojang_API#Query_player_attributes
 func ServicesPlayerAttributes(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, _ *Player) error {
 		res := playerAttributesResponse{
@@ -194,7 +194,7 @@ type playerCertificatesResponse struct {
 }
 
 // POST /player/certificates
-// https://wiki.vg/Mojang_API#Player_Certificates
+// https://minecraft.wiki/w/Mojang_API#Get_keypair_for_signature
 func ServicesPlayerCertificates(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -323,7 +323,7 @@ func ServicesPlayerCertificates(app *App) func(c echo.Context) error {
 }
 
 // POST /minecraft/profile/skins
-// https://wiki.vg/Mojang_API#Upload_Skin
+// https://minecraft.wiki/w/Mojang_API#Upload_skin
 func ServicesUploadSkin(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		if !app.Config.AllowSkins {
@@ -362,7 +362,7 @@ func ServicesUploadSkin(app *App) func(c echo.Context) error {
 }
 
 // DELETE /minecraft/profile/skins/active
-// https://wiki.vg/Mojang_API#Reset_Skin
+// https://minecraft.wiki/w/Mojang_API#Reset_skin
 func ServicesResetSkin(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		err := app.SetSkinAndSave(player, nil)
@@ -375,7 +375,7 @@ func ServicesResetSkin(app *App) func(c echo.Context) error {
 }
 
 // DELETE /minecraft/profile/capes/active
-// https://wiki.vg/Mojang_API#Hide_Cape
+// https://minecraft.wiki/w/Mojang_API#Hide_cape
 func ServicesHideCape(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		err := app.SetCapeAndSave(player, nil)
@@ -394,7 +394,7 @@ type nameChangeResponse struct {
 }
 
 // GET /minecraft/profile/namechange
-// https://wiki.vg/Mojang_API#Profile_Name_Change_Information
+// https://minecraft.wiki/w/Mojang_API#Query_player's_name_change_information
 func ServicesNameChange(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		changedAt := player.NameLastChangedAt.Format(time.RFC3339Nano)
@@ -409,7 +409,6 @@ func ServicesNameChange(app *App) func(c echo.Context) error {
 }
 
 // GET /rollout/v1/msamigration
-// https://wiki.vg/Mojang_API#Get_Account_Migration_Information
 func ServicesMSAMigration(app *App) func(c echo.Context) error {
 	type msaMigrationResponse struct {
 		Feature string `json:"feature"`
@@ -429,7 +428,7 @@ type blocklistResponse struct {
 }
 
 // GET /privacy/blocklist
-// https://wiki.vg/Mojang_API#Player_Blocklist
+// https://minecraft.wiki/w/Mojang_API#Get_list_of_blocked_users
 func ServicesBlocklist(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, _ *Player) error {
 		res := blocklistResponse{
@@ -444,7 +443,7 @@ type nameAvailabilityResponse struct {
 }
 
 // GET /minecraft/profile/name/:playerName/available
-// https://wiki.vg/Mojang_API#Name_Availability
+// https://minecraft.wiki/w/Mojang_API#Check_name_availability
 func ServicesNameAvailability(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		playerName := c.Param("playerName")
@@ -480,7 +479,7 @@ type changeNameErrorResponse struct {
 }
 
 // PUT /minecraft/profile/name/:playerName
-// https://wiki.vg/Mojang_API#Change_Name
+// https://minecraft.wiki/w/Mojang_API#Change_name
 func ServicesChangeName(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, player *Player) error {
 		playerName := c.Param("playerName")
@@ -563,6 +562,7 @@ func SerializedKeyToPublicKey(serializedKey SerializedKey) (*rsa.PublicKey, erro
 }
 
 // GET /publickeys
+// https://minecraft.wiki/w/Mojang_API#Get_Mojang_public_keys
 func ServicesPublicKeys(app *App) func(c echo.Context) error {
 	serializedProfilePropertyKeys := make([]SerializedKey, 0, len(app.ProfilePropertyKeys))
 	serializedPlayerCertificateKeys := make([]SerializedKey, 0, len(app.PlayerCertificateKeys))

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ type sessionJoinRequest struct {
 }
 
 // /session/minecraft/join
-// https://wiki.vg/Protocol_Encryption#Client
+// https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol_Encryption#Client
 func SessionJoin(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(sessionJoinRequest)
@@ -178,7 +178,7 @@ func (app *App) hasJoined(c *echo.Context, playerName string, serverID string, l
 }
 
 // /session/minecraft/hasJoined
-// https://c4k3.github.io/wiki.vg/Protocol_Encryption.html#Server
+// https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol_Encryption#Server
 func SessionHasJoined(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		playerName := c.QueryParam("username")
@@ -197,7 +197,7 @@ func SessionCheckServer(app *App) func(c echo.Context) error {
 }
 
 // /session/minecraft/profile/:id
-// https://wiki.vg/Mojang_API#UUID_to_Profile_and_Skin.2FCape
+// https://minecraft.wiki/w/Mojang_API#Query_player's_skin_and_cape
 func SessionProfile(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		id := c.Param("id")
@@ -274,7 +274,7 @@ func SessionProfile(app *App) func(c echo.Context) error {
 }
 
 // /blockedservers
-// https://wiki.vg/Mojang_API#Blocked_Servers
+// https://minecraft.wiki/w/Mojang_API#Query_blocked_server_list
 func SessionBlockedServers(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		return c.NoContent(http.StatusOK)


### PR DESCRIPTION
According to users on the Minecraft wiki Discord, these links should be somewhat stable (though probably not the names of the `#` fragments), and using them is better than broken wiki.vg links. A couple unimportant links were dropped since they are not yet merged into the Minecraft Wiki's [Mojang API page](https://minecraft.wiki/w/Mojang_API).