### PR TITLE
[Bug fix] Cannot set prefered language when creating new user via API.

### DIFF
--- a/user.go
+++ b/user.go
@@ -265,7 +265,7 @@ func (app *App) CreateUser(
 		PlayerName:        *playerName,
 		OfflineUUID:       offlineUUID,
 		FallbackPlayer:    *fallbackPlayer,
-		PreferredLanguage: app.Config.DefaultPreferredLanguage,
+		PreferredLanguage: *preferredLanguage,
 		SkinModel:         *skinModel,
 		SkinHash:          MakeNullString(skinHash),
 		CapeHash:          MakeNullString(capeHash),


### PR DESCRIPTION
I found it out by chance that whatever language I set when using api POST /drasl/api/v1/users, the user's prefered language would always be English, the default option in config file. Anyway this is a travial fix, but it make sense, so I hope it would be merged. :) 