### PR TITLE
Fix a couple API bugs

### DIFF
--- a/api.go
+++ b/api.go
@@ -100,10 +100,9 @@ func IsDeprecatedAPIPath(path_ string) mo.Option[int] {
 		match := re.FindStringSubmatch(split[3])
 		if len(match) == 2 {
 			version, err := strconv.Atoi(match[1])
-			if err != nil {
-				return mo.None[int]()
+			if err == nil && version != API_MAJOR_VERSION {
+				return mo.Some(version)
 			}
-			return mo.Some(version)
 		}
 	}
 

--- a/api_test.go
+++ b/api_test.go
@@ -104,10 +104,16 @@ func (ts *TestSuite) testAPIGetUser(t *testing.T) {
 	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
 	assert.Equal(t, nonAdmin.UUID, response.UUID)
 
+	// nonexistent user should get StatusNotFound
+	var err APIError
+	rec = ts.Get(t, ts.Server, DRASL_API_PREFIX+"/users/00000000-0000-0000-0000-000000000000", nil, &admin.APIToken)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&err))
+	assert.Equal(t, "Unknown UUID", err.Message)
+
 	// user2 (not admin) should get a StatusForbidden
 	rec = ts.Get(t, ts.Server, DRASL_API_PREFIX+"/users/"+admin.UUID, nil, &nonAdmin.APIToken)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
-	var err APIError
 	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&err))
 
 	assert.Nil(t, ts.App.DeleteUser(&GOD, admin))

--- a/user.go
+++ b/user.go
@@ -328,6 +328,9 @@ func (app *App) UpdateUser(
 		if !callerIsAdmin {
 			return User{}, NewBadRequestUserError("Cannot change admin status of user without having admin privileges yourself.")
 		}
+		if !(*isAdmin) && app.IsDefaultAdmin(&user) {
+			return User{}, NewBadRequestUserError("Cannot revoke admin status of a default admin.")
+		}
 		user.IsAdmin = *isAdmin
 	}
 


### PR DESCRIPTION
- DefaultAdmins could have their admin privileges revoked by `PATCH /drasl/api/v2/users/{uuid}`
- Fix 404 APIErrors returning "Version 2 of this API is deprecated."