### PR TITLE
Add swag to builddeps in installation.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 prefix ?= /usr
 .DEFAULT_GOAL := build
 
+# TODO probably use `go tool` for this eventually
+SWAG := $(shell command -v swag || echo 'go run github.com/swaggo/swag/cmd/swag@v1.16.4')
+
 npm-install:
 	npm install
 
 swag:
-	swag init --generalInfo api.go --output . --outputTypes json
+	$(SWAG) init --generalInfo api.go --output . --outputTypes json
 
 prebuild: npm-install swag
 	node esbuild.config.js

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Otherwise, install build dependencies. Go 1.19 or later is required:
 
 ```
 sudo apt install make golang gcc nodejs npm    # Debian
-sudo dnf install make go gcc nodejs npm        # Fedora
+sudo dnf install make golang gcc nodejs npm    # Fedora
 sudo pacman -S make go gcc nodejs npm          # Arch Linux
+
 go install github.com/swaggo/swag/cmd/swag@latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ Otherwise, install build dependencies. Go 1.19 or later is required:
 sudo apt install make golang gcc nodejs npm    # Debian
 sudo dnf install make golang gcc nodejs npm    # Fedora
 sudo pacman -S make go gcc nodejs npm          # Arch Linux
-
-go install github.com/swaggo/swag/cmd/swag@latest
 ```
 
 Then build the program with:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -138,8 +138,10 @@ This is a more declarative version of the Docker setup from above.
 
    ```
    sudo apt install make golang gcc nodejs npm # Debian
-   sudo dnf install make go gcc nodejs npm     # Fedora
+   sudo dnf install make golang gcc nodejs npm # Fedora
    sudo pacman -S make go gcc nodejs npm       # Arch Linux
+
+   go install github.com/swaggo/swag/cmd/swag@latest
    ```
 
 2. Clone the repository:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -150,7 +150,12 @@ This is a more declarative version of the Docker setup from above.
    cd drasl
    ```
 
-3. `sudo make install`
+3. Build and install:
+
+   ```
+   make
+   sudo make install
+   ```
 
 4. Create `/etc/drasl/config.toml` and fill it out according to one of the examples in [doc/recipes.md](recipes.md).
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -140,8 +140,6 @@ This is a more declarative version of the Docker setup from above.
    sudo apt install make golang gcc nodejs npm # Debian
    sudo dnf install make golang gcc nodejs npm # Fedora
    sudo pacman -S make go gcc nodejs npm       # Arch Linux
-
-   go install github.com/swaggo/swag/cmd/swag@latest
    ```
 
 2. Clone the repository:


### PR DESCRIPTION
Earlier, I added swag to the list of build dependencies in README.md but not the list in installation.md.