### PR TITLE
Updated links to migrated wiki.vg

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ See [doc/usage.md](doc/usage.md) for post-installation instructions and guidance
 
 Drasl has its own API for managing users and invitations, but consider it in a beta state. v1 of this API is likely to be deprecated quickly. Documentation is [here](https://doc.drasl.unmojang.org).
 
-Drasl implements the Mojang API, documented here on [wiki.vg](https://wiki.vg):
+Drasl implements the Mojang API, documented here on [minecraft.wiki](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge) (successor of the [wiki.vg](https://wiki.vg/)):
 
-- [Mojang API](https://wiki.vg/Mojang_API)
-- [Legacy Mojang Authentication](https://wiki.vg/Legacy_Mojang_Authentication)
-- [Protocol Encryption](https://wiki.vg/Protocol_Encryption)
+- [Mojang API](https://minecraft.wiki/w/Mojang_API)
+- [Legacy Mojang Authentication](https://minecraft.wiki/w/Legacy_Minecraft_authentication)
+- [Protocol Encryption](https://minecraft.wiki/w/Protocol_encryption)
 
 If you find that an API route behaves substantively different than the Mojang API, please [file an issue](https://github.com/unmojang/drasl/issues).
 

--- a/account.go
+++ b/account.go
@@ -18,7 +18,7 @@ type playerNameToUUIDResponse struct {
 }
 
 // GET /users/profiles/minecraft/:playerName
-// https://wiki.vg/Mojang_API#Username_to_UUID
+// https://minecraft.wiki/w/Mojang_API#Query_player's_UUID
 func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		playerName := c.Param("playerName")
@@ -80,7 +80,7 @@ func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 
 // POST /profiles/minecraft
 // POST /minecraft/profile/lookup/bulk/byname
-// https://wiki.vg/Mojang_API#Usernames_to_UUIDs
+// https://minecraft.wiki/w/Mojang_API#Query_player_UUIDs_in_batch
 func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		var playerNames []string
@@ -169,7 +169,7 @@ func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 }
 
 // GET /user/security/location
-// https://wiki.vg/Mojang_API#Verify_Security_Location
+// https://wiki.vg/Mojang_API#Verify_Security_Location // TODO by RareScrap: I can't find the right doc in minecraft.wiki https://minecraft.wiki/w/Mojang_API 
 func AccountVerifySecurityLocation(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)

--- a/auth.go
+++ b/auth.go
@@ -75,7 +75,7 @@ type authenticateResponse struct {
 }
 
 // POST /authenticate
-// https://wiki.vg/Legacy_Mojang_Authentication#Authenticate
+// https://minecraft.wiki/w/Yggdrasil#Authenticate
 func AuthAuthenticate(app *App) func(c echo.Context) error {
 	return func(c echo.Context) (err error) {
 		req := new(authenticateRequest)
@@ -223,7 +223,7 @@ type refreshResponse struct {
 }
 
 // POST /refresh
-// https://wiki.vg/Legacy_Mojang_Authentication#Refresh
+// https://minecraft.wiki/w/Yggdrasil#Refresh
 func AuthRefresh(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(refreshRequest)
@@ -288,7 +288,7 @@ type validateRequest struct {
 }
 
 // POST /validate
-// https://wiki.vg/Legacy_Mojang_Authentication#Validate
+// https://minecraft.wiki/w/Yggdrasil#Validate
 func AuthValidate(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(validateRequest)
@@ -311,7 +311,7 @@ type signoutRequest struct {
 }
 
 // POST /signout
-// https://wiki.vg/Legacy_Mojang_Authentication#Signout
+// https://minecraft.wiki/w/Yggdrasil#Signout
 func AuthSignout(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(signoutRequest)
@@ -349,7 +349,7 @@ type invalidateRequest struct {
 }
 
 // POST /invalidate
-// https://wiki.vg/Legacy_Mojang_Authentication#Invalidate
+// https://minecraft.wiki/w/Yggdrasil#Invalidate
 func AuthInvalidate(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(invalidateRequest)

--- a/services.go
+++ b/services.go
@@ -57,7 +57,7 @@ type ServicesProfile struct {
 	ID    string                `json:"id"`
 	Name  string                `json:"name"`
 	Skins []ServicesProfileSkin `json:"skins"`
-	Capes []string              `json:"capes"` // TODO implement capes, they are undocumented on https://wiki.vg/Mojang_API#Profile_Information
+	Capes []string              `json:"capes"` // TODO implement capes, they are undocumented on https://minecraft.wiki/w/Mojang_API#Query_player_profile
 }
 
 func getServicesProfile(app *App, user *User) (ServicesProfile, error) {
@@ -122,7 +122,7 @@ func getServicesProfile(app *App, user *User) (ServicesProfile, error) {
 }
 
 // GET /minecraft/profile
-// https://wiki.vg/Mojang_API#Profile_Information
+// https://wiki.vg/Mojang_API#Profile_Information // TODO by RareScrap: I can't find the right doc in minecraft.wiki https://minecraft.wiki/w/Mojang_API
 func ServicesProfileInformation(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		servicesProfile, err := getServicesProfile(app, user)
@@ -157,7 +157,7 @@ type playerAttributesResponse struct {
 }
 
 // GET /player/attributes
-// https://wiki.vg/Mojang_API#Player_Attributes
+// https://minecraft.wiki/w/Mojang_API#Query_player_attributes
 func ServicesPlayerAttributes(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, _ *User) error {
 		res := playerAttributesResponse{
@@ -191,7 +191,7 @@ type playerCertificatesResponse struct {
 }
 
 // POST /player/certificates
-// https://wiki.vg/Mojang_API#Player_Certificates
+// https://minecraft.wiki/w/Mojang_API#Get_keypair_for_signature
 func ServicesPlayerCertificates(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -320,7 +320,7 @@ func ServicesPlayerCertificates(app *App) func(c echo.Context) error {
 }
 
 // POST /minecraft/profile/skins
-// https://wiki.vg/Mojang_API#Upload_Skin
+// https://minecraft.wiki/w/Mojang_API#Change_skin
 func ServicesUploadSkin(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		if !app.Config.AllowSkins {
@@ -359,7 +359,7 @@ func ServicesUploadSkin(app *App) func(c echo.Context) error {
 }
 
 // DELETE /minecraft/profile/skins/active
-// https://wiki.vg/Mojang_API#Reset_Skin
+// https://minecraft.wiki/w/Mojang_API#Reset_skin
 func ServicesResetSkin(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		err := app.SetSkinAndSave(user, nil)
@@ -372,7 +372,7 @@ func ServicesResetSkin(app *App) func(c echo.Context) error {
 }
 
 // DELETE /minecraft/profile/capes/active
-// https://wiki.vg/Mojang_API#Hide_Cape
+// https://minecraft.wiki/w/Mojang_API#Show_cape
 func ServicesHideCape(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		err := app.SetCapeAndSave(user, nil)
@@ -391,7 +391,7 @@ type nameChangeResponse struct {
 }
 
 // GET /minecraft/profile/namechange
-// https://wiki.vg/Mojang_API#Profile_Name_Change_Information
+// https://minecraft.wiki/w/Mojang_API#Query_player's_name_change_information
 func ServicesNameChange(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		changedAt := user.NameLastChangedAt.Format(time.RFC3339Nano)
@@ -406,7 +406,7 @@ func ServicesNameChange(app *App) func(c echo.Context) error {
 }
 
 // GET /rollout/v1/msamigration
-// https://wiki.vg/Mojang_API#Get_Account_Migration_Information
+// https://wiki.vg/Mojang_API#Get_Account_Migration_Information // TODO by RareScrap: I can't find the right doc in minecraft.wiki https://minecraft.wiki/w/Mojang_API
 func ServicesMSAMigration(app *App) func(c echo.Context) error {
 	type msaMigrationResponse struct {
 		Feature string `json:"feature"`
@@ -426,7 +426,7 @@ type blocklistResponse struct {
 }
 
 // GET /privacy/blocklist
-// https://wiki.vg/Mojang_API#Player_Blocklist
+// https://minecraft.wiki/w/Mojang_API#Get_list_of_blocked_users
 func ServicesBlocklist(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		res := blocklistResponse{
@@ -441,7 +441,7 @@ type nameAvailabilityResponse struct {
 }
 
 // GET /minecraft/profile/name/:playerName/available
-// https://wiki.vg/Mojang_API#Name_Availability
+// https://minecraft.wiki/w/Mojang_API#Check_name_availability
 func ServicesNameAvailability(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		playerName := c.Param("playerName")
@@ -477,7 +477,7 @@ type changeNameErrorResponse struct {
 }
 
 // PUT /minecraft/profile/name/:playerName
-// https://wiki.vg/Mojang_API#Change_Name
+// https://minecraft.wiki/w/Mojang_API#Change_name
 func ServicesChangeName(app *App) func(c echo.Context) error {
 	return withBearerAuthentication(app, func(c echo.Context, user *User) error {
 		playerName := c.Param("playerName")

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ type sessionJoinRequest struct {
 }
 
 // /session/minecraft/join
-// https://wiki.vg/Protocol_Encryption#Client
+// https://minecraft.wiki/w/Protocol_encryption#Client
 func SessionJoin(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		req := new(sessionJoinRequest)
@@ -178,7 +178,7 @@ func (app *App) hasJoined(c *echo.Context, playerName string, serverID string, l
 }
 
 // /session/minecraft/hasJoined
-// https://c4k3.github.io/wiki.vg/Protocol_Encryption.html#Server
+// https://minecraft.wiki/w/Protocol_encryption#Server
 func SessionHasJoined(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		playerName := c.QueryParam("username")
@@ -197,7 +197,7 @@ func SessionCheckServer(app *App) func(c echo.Context) error {
 }
 
 // /session/minecraft/profile/:id
-// https://wiki.vg/Mojang_API#UUID_to_Profile_and_Skin.2FCape
+// https://minecraft.wiki/w/Mojang_API#Query_player's_skin_and_cape
 func SessionProfile(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		id := c.Param("id")
@@ -274,7 +274,7 @@ func SessionProfile(app *App) func(c echo.Context) error {
 }
 
 // /blockedservers
-// https://wiki.vg/Mojang_API#Blocked_Servers
+// https://minecraft.wiki/w/Mojang_API#Query_blocked_server_list
 func SessionBlockedServers(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		return c.NoContent(http.StatusOK)


### PR DESCRIPTION
> The official [wiki.vg](https://wiki.vg) domain has been shut down by the owner. If you were unaware of this, you can learn more about why this has happened by reading [TkTech's official article](https://tkte.ch/articles/2024/11/11/sunsetting.html). I would try to summarize why the shutdown has happened, but I think it is better said by TkTech. Just know that no data is being lost! wiki.vg is being merged into the official Minecraft wiki, which you can [learn more about here](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge).
> 
> -- <cite>[Minecraft Protocol Discord community](https://discord.com/channels/934181095136710696/1313319562258813011/1313323277820887051)</cite>

So I've updated the wiki.vg links to its successor minecraft.wiki