### PR TITLE
Remove link to tinytengu/minecraft-authlib from view/root.tmpl

### DIFF
--- a/view/root.tmpl
+++ b/view/root.tmpl
@@ -128,13 +128,5 @@ java -Xmx1024M -Xms1024M \
     >.
   </p>
 
-  <p>
-    Alternatively, you can patch your server to use a newer version of Mojang's
-    authlib that supports custom API servers. See
-    <a href="https://github.com/tinytengu/minecraft-authlib"
-      >https://github.com/tinytengu/minecraft-authlib</a
-    >.
-  </p>
-
   {{ template "footer" . }}
 {{ end }}


### PR DESCRIPTION
tinytengu has deleted their GitHub account, and rather than host a mirror, due to legal concerns I think it'd be better to remove it entirely.