### PR TITLE
Batch and rate limit requests to POST /profiles/minecraft on fallback API servers

### DIFF
--- a/account.go
+++ b/account.go
@@ -1,21 +1,180 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/mo"
 	"gorm.io/gorm"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
+	"time"
 )
 
-type playerNameToUUIDResponse struct {
+type PlayerNameToIDResponse struct {
 	Name string `json:"name"`
 	ID   string `json:"id"`
+}
+
+type playerNameToIDJob struct {
+	LowerName string
+	ReturnCh  chan mo.Option[PlayerNameToIDResponse]
+}
+
+func (fallbackAPIServer *FallbackAPIServer) PlayerNamesToIDs(remainingLowerNames mapset.Set[string]) []PlayerNameToIDResponse {
+	responses := make([]PlayerNameToIDResponse, 0, remainingLowerNames.Cardinality())
+
+	// Use responses from the cache, if available.
+	if fallbackAPIServer.PlayerNameToIDCache != nil {
+		for _, lowerName := range remainingLowerNames.ToSlice() {
+			cachedResponse, found := fallbackAPIServer.PlayerNameToIDCache.Get(lowerName)
+			if found {
+				remainingLowerNames.Remove(lowerName)
+				if response, isPresent := cachedResponse.(mo.Option[PlayerNameToIDResponse]).Get(); isPresent {
+					responses = append(responses, response)
+				}
+			}
+		}
+	}
+
+	playerNameToIDJobs := make([]playerNameToIDJob, 0, remainingLowerNames.Cardinality())
+	for lowerName := range mapset.Elements(remainingLowerNames) {
+		playerNameToIDJobs = append(playerNameToIDJobs, playerNameToIDJob{
+			LowerName: lowerName,
+			ReturnCh:  make(chan mo.Option[PlayerNameToIDResponse], 1),
+		})
+	}
+	fallbackAPIServer.PlayerNameToIDJobCh <- playerNameToIDJobs
+
+	for _, job := range playerNameToIDJobs {
+		maybeRes := <-job.ReturnCh
+		if res, ok := maybeRes.Get(); ok {
+			responses = append(responses, res)
+		}
+	}
+	return responses
+}
+
+func (fallbackAPIServer *FallbackAPIServer) PlayerNamesToIDsWorker() {
+	// All communication with the POST /profiles/minecraft (a.k.a. POST
+	// /minecraft/profile/lookup/bulk/byname) route on a fallback API server is
+	// done by a single goroutine running this function. It buffers a queue of
+	// requested (lowercase) player names and makes requests to the fallback
+	// API server in batches of MAX_PLAYER_NAMES_TO_IDS, waiting at least
+	// MAX_PLAYER_NAMES_TO_IDS_INTERVAL in between requests, in order to avoid
+	// rate-limiting.
+
+	url := fallbackAPIServer.Config.AccountURL + "/profiles/minecraft"
+
+	// Queue of player names to fetch that may exceed MAX_PLAYER_NAMES_TO_IDS
+	// in size
+	lowerNameQueue := make([]*string, 0)
+
+	// Map lowercase player name to a list of return channels where we should
+	// send the result of the query for that lowercase player name
+	lowerNameToResponseChs := make(map[string][]chan mo.Option[PlayerNameToIDResponse])
+
+	var timeout <-chan time.Time = nil
+
+	for {
+		select {
+		case jobs := <-fallbackAPIServer.PlayerNameToIDJobCh:
+			for _, job := range PtrSlice(jobs) {
+				// Double-check the cache
+				if fallbackAPIServer.PlayerNameToIDCache != nil {
+					cachedResponse, found := fallbackAPIServer.PlayerNameToIDCache.Get(job.LowerName)
+					if found {
+						job.ReturnCh <- cachedResponse.(mo.Option[PlayerNameToIDResponse])
+						continue
+					}
+				}
+
+				if _, ok := lowerNameToResponseChs[job.LowerName]; !ok {
+					lowerNameQueue = append(lowerNameQueue, &job.LowerName)
+				}
+				lowerNameToResponseChs[job.LowerName] = append(lowerNameToResponseChs[job.LowerName], job.ReturnCh)
+			}
+		case <-timeout:
+			timeout = nil
+		}
+
+		// Wait until we have player names in the queue AND have waited long
+		// enough to make another request
+		if !(len(lowerNameQueue) > 0 && timeout == nil) {
+			continue
+		}
+
+		// Dequeue the next batch of MAX_PLAYER_NAMES_TO_IDS lowercase player names
+		batchSize := min(len(lowerNameQueue), MAX_PLAYER_NAMES_TO_IDS)
+		batch := lowerNameQueue[:batchSize]
+		lowerNameQueue = lowerNameQueue[batchSize:]
+
+		fallbackResponses, fallbackError := (func() ([]PlayerNameToIDResponse, error) {
+			body, err := json.Marshal(batch)
+			if err != nil {
+				return nil, err
+			}
+
+			res, err := MakeHTTPClient().Post(url, "application/json", bytes.NewBuffer(body))
+			if err != nil {
+				return nil, err
+			}
+			defer res.Body.Close()
+
+			if res.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("received status code %d", res.StatusCode)
+			}
+
+			buf := new(bytes.Buffer)
+			_, err = buf.ReadFrom(res.Body)
+			if err != nil {
+				return nil, err
+			}
+
+			var fallbackResponses []PlayerNameToIDResponse
+			err = json.Unmarshal(buf.Bytes(), &fallbackResponses)
+			if err != nil {
+				return nil, err
+			}
+			return fallbackResponses, nil
+		})()
+
+		timeout = time.After(MAX_PLAYER_NAMES_TO_IDS_INTERVAL)
+
+		lowerNameToResponse := make(map[string]*PlayerNameToIDResponse)
+		if fallbackError != nil {
+			log.Printf("Error requesting player IDs from fallback API server at %s: %s", url, fallbackError)
+		} else {
+			for _, fallbackResponse := range PtrSlice(fallbackResponses) {
+				lowerName := strings.ToLower(fallbackResponse.Name)
+				lowerNameToResponse[lowerName] = fallbackResponse
+			}
+		}
+
+		for _, lowerName := range batch {
+			if fallbackError == nil && fallbackAPIServer.PlayerNameToIDCache != nil {
+				ttl := time.Duration(fallbackAPIServer.Config.CacheTTLSeconds) * time.Second
+				if res, ok := lowerNameToResponse[*lowerName]; ok {
+					fallbackAPIServer.PlayerNameToIDCache.SetWithTTL(*lowerName, mo.Some(*res), 0, ttl)
+				} else {
+					fallbackAPIServer.PlayerNameToIDCache.SetWithTTL(*lowerName, mo.None[PlayerNameToIDResponse](), 0, ttl)
+				}
+				fallbackAPIServer.PlayerNameToIDCache.Wait()
+			}
+			for _, responseCh := range lowerNameToResponseChs[*lowerName] {
+				if res, ok := lowerNameToResponse[*lowerName]; ok {
+					responseCh <- mo.Some(*res)
+				} else {
+					responseCh <- mo.None[PlayerNameToIDResponse]()
+				}
+			}
+		}
+		clear(lowerNameToResponseChs)
+	}
 }
 
 // GET /users/profiles/minecraft/:playerName
@@ -25,39 +184,27 @@ func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		playerName := c.Param("playerName")
 
+		if len(playerName) > Constants.MaxPlayerNameLength {
+			// This error message is consistent with GET
+			// https://api.mojang.com/users/profiles/minecraft/:playerName as
+			// of 2025-04-02
+			errorMessage := fmt.Sprintf("getProfileName.name: Invalid profile name, getProfileName.name: size must be between 1 and %d", Constants.MaxPlayerNameLength)
+			return &YggdrasilError{
+				Code:         http.StatusBadRequest,
+				Error_:       mo.Some("CONSTRAINT_VIOLATION"),
+				ErrorMessage: mo.Some(errorMessage),
+			}
+		}
+
+		lowerName := strings.ToLower(playerName)
+
 		var player Player
-		result := app.DB.First(&player, "name = ?", playerName)
+		result := app.DB.First(&player, "name = ?", lowerName)
 		if result.Error != nil {
 			if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-				for _, fallbackAPIServer := range app.Config.FallbackAPIServers {
-					reqURL, err := url.JoinPath(fallbackAPIServer.AccountURL, "profiles/minecraft")
-					if err != nil {
-						log.Println(err)
-						continue
-					}
-
-					payload := []string{playerName}
-					body, err := json.Marshal(payload)
-					if err != nil {
-						return err
-					}
-
-					res, err := app.CachedPostJSON(reqURL, body, fallbackAPIServer.CacheTTLSeconds)
-					if err != nil {
-						log.Printf("Couldn't access fallback API server at %s: %s\n", reqURL, err)
-						continue
-					}
-					if res.StatusCode != http.StatusOK {
-						continue
-					}
-
-					var fallbackResponses []playerNameToUUIDResponse
-					err = json.Unmarshal(res.BodyBytes, &fallbackResponses)
-					if err != nil {
-						log.Printf("Received invalid response from fallback API server at %s\n", reqURL)
-						continue
-					}
-					if len(fallbackResponses) == 1 && strings.EqualFold(playerName, fallbackResponses[0].Name) {
+				for _, fallbackAPIServer := range app.FallbackAPIServers {
+					fallbackResponses := fallbackAPIServer.PlayerNamesToIDs(mapset.NewSet(lowerName))
+					if len(fallbackResponses) == 1 && strings.EqualFold(lowerName, fallbackResponses[0].Name) {
 						return c.JSON(http.StatusOK, fallbackResponses[0])
 					}
 				}
@@ -71,7 +218,7 @@ func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 		if err != nil {
 			return err
 		}
-		res := playerNameToUUIDResponse{
+		res := PlayerNameToIDResponse{
 			Name: player.Name,
 			ID:   id,
 		}
@@ -90,25 +237,48 @@ func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 			return err
 		}
 
-		n := len(playerNames)
-		if !(1 <= n && n <= 10) {
+		if len(playerNames) == 0 {
+			// This error message is consistent with POST
+			// https://api.mojang.com/profiles/minecraft as of 2025-04-02
+			errorMessage := fmt.Sprintf("getProfileName.profileNames: must not be empty")
 			return &YggdrasilError{
 				Code:         http.StatusBadRequest,
 				Error_:       mo.Some("CONSTRAINT_VIOLATION"),
-				ErrorMessage: mo.Some("getProfileName.profileNames: size must be between 1 and 10"),
+				ErrorMessage: mo.Some(errorMessage),
+			}
+		} else if len(playerNames) > MAX_PLAYER_NAMES_TO_IDS {
+			// This error message is consistent with POST
+			// https://api.mojang.com/profiles/minecraft as of 2025-04-02
+			errorMessage := fmt.Sprintf("getProfileName.profileNames: size must be between 0 and %d", MAX_PLAYER_NAMES_TO_IDS)
+			return &YggdrasilError{
+				Code:         http.StatusBadRequest,
+				Error_:       mo.Some("CONSTRAINT_VIOLATION"),
+				ErrorMessage: mo.Some(errorMessage),
 			}
 		}
 
-		response := make([]playerNameToUUIDResponse, 0, n)
+		response := make([]PlayerNameToIDResponse, 0, len(playerNames))
 
-		remainingPlayers := map[string]bool{}
-		for _, playerName := range playerNames {
+		remainingLowerNames := mapset.NewSet[string]()
+		for i, playerName := range playerNames {
+			if !(1 <= len(playerName) && len(playerName) <= Constants.MaxPlayerNameLength) {
+				// This error message is consistent with POST
+				// https://api.mojang.com/profiles/minecraft as of 2025-04-02
+				errorMessage := fmt.Sprintf("getProfileName.profileNames[%d].<list element>: size must be between 1 and %d, getProfileName.profileNames[%d].<list element>: Invalid profile name", i, Constants.MaxPlayerNameLength, 1)
+				return &YggdrasilError{
+					Code:         http.StatusBadRequest,
+					Error_:       mo.Some("CONSTRAINT_VIOLATION"),
+					ErrorMessage: mo.Some(errorMessage),
+				}
+			}
+			remainingLowerNames.Add(strings.ToLower(playerName))
+		}
+
+		for _, lowerName := range remainingLowerNames.ToSlice() {
 			var player Player
-			result := app.DB.First(&player, "name = ?", playerName)
+			result := app.DB.First(&player, "name = ?", lowerName)
 			if result.Error != nil {
-				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-					remainingPlayers[strings.ToLower(playerName)] = true
-				} else {
+				if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
 					return result.Error
 				}
 			} else {
@@ -116,57 +286,27 @@ func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 				if err != nil {
 					return err
 				}
-				playerRes := playerNameToUUIDResponse{
+				playerRes := PlayerNameToIDResponse{
 					Name: player.Name,
 					ID:   id,
 				}
 				response = append(response, playerRes)
+				remainingLowerNames.Remove(lowerName)
 			}
 		}
 
-		for _, fallbackAPIServer := range app.Config.FallbackAPIServers {
-			reqURL, err := url.JoinPath(fallbackAPIServer.AccountURL, "profiles/minecraft")
-			if err != nil {
-				log.Println(err)
-				continue
+		for _, fallbackAPIServer := range app.FallbackAPIServers {
+			if remainingLowerNames.Cardinality() == 0 {
+				break
 			}
 
-			payload := make([]string, 0, len(remainingPlayers))
-			for remainingPlayer := range remainingPlayers {
-				payload = append(payload, remainingPlayer)
-			}
-			body, err := json.Marshal(payload)
-			if err != nil {
-				return err
-			}
-
-			res, err := app.CachedPostJSON(reqURL, body, fallbackAPIServer.CacheTTLSeconds)
-			if err != nil {
-				log.Printf("Couldn't access fallback API server at %s: %s\n", reqURL, err)
-				continue
-			}
-
-			if res.StatusCode != http.StatusOK {
-				continue
-			}
-
-			var fallbackResponses []playerNameToUUIDResponse
-			err = json.Unmarshal(res.BodyBytes, &fallbackResponses)
-			if err != nil {
-				log.Printf("Received invalid response from fallback API server at %s\n", reqURL)
-				continue
-			}
-
+			fallbackResponses := fallbackAPIServer.PlayerNamesToIDs(remainingLowerNames)
 			for _, fallbackResponse := range fallbackResponses {
 				lowerName := strings.ToLower(fallbackResponse.Name)
-				if _, ok := remainingPlayers[lowerName]; ok {
+				if remainingLowerNames.Contains(lowerName) {
 					response = append(response, fallbackResponse)
-					delete(remainingPlayers, lowerName)
+					remainingLowerNames.Remove(lowerName)
 				}
-			}
-
-			if len(remainingPlayers) == 0 {
-				break
 			}
 		}
 

--- a/account.go
+++ b/account.go
@@ -211,11 +211,10 @@ func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 			// This error message is consistent with POST
 			// https://api.mojang.com/users/profiles/minecraft/:playerName as
 			// of 2025-04-03
-			errorMessage := fmt.Sprintf("getProfileName.name: Invalid profile name")
 			return &YggdrasilError{
 				Code:         http.StatusBadRequest,
 				Error_:       mo.Some("CONSTRAINT_VIOLATION"),
-				ErrorMessage: mo.Some(errorMessage),
+				ErrorMessage: mo.Some("getProfileName.name: Invalid profile name"),
 			}
 		}
 
@@ -261,11 +260,10 @@ func AccountPlayerNamesToIDs(app *App) func(c echo.Context) error {
 		if len(playerNames) == 0 {
 			// This error message is consistent with POST
 			// https://api.mojang.com/profiles/minecraft as of 2025-04-02
-			errorMessage := fmt.Sprintf("getProfileName.profileNames: must not be empty")
 			return &YggdrasilError{
 				Code:         http.StatusBadRequest,
 				Error_:       mo.Some("CONSTRAINT_VIOLATION"),
-				ErrorMessage: mo.Some(errorMessage),
+				ErrorMessage: mo.Some("getProfileName.profileNames: must not be empty"),
 			}
 		}
 		if len(playerNames) > MAX_PLAYER_NAMES_TO_IDS {

--- a/account.go
+++ b/account.go
@@ -19,6 +19,7 @@ type playerNameToUUIDResponse struct {
 }
 
 // GET /users/profiles/minecraft/:playerName
+// GET /minecraft/profile/lookup/name/:playerName
 // https://minecraft.wiki/w/Mojang_API#Query_player's_UUID
 func AccountPlayerNameToID(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {

--- a/authlib_injector_test.go
+++ b/authlib_injector_test.go
@@ -40,7 +40,7 @@ func TestAuthlibInjector(t *testing.T) {
 		config := testConfig()
 		fallback := ts.ToFallbackAPIServer(ts.AuxApp, "Aux")
 		fallback.SkinDomains = []string{FALLBACK_SKIN_DOMAIN_A, FALLBACK_SKIN_DOMAIN_B}
-		config.FallbackAPIServers = []FallbackAPIServer{fallback}
+		config.FallbackAPIServers = []FallbackAPIServerConfig{fallback}
 		ts.Setup(config)
 		defer ts.Teardown()
 

--- a/common.go
+++ b/common.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/dgraph-io/ristretto"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -687,7 +688,7 @@ func (app *App) GetFallbackSkinTexturesProperty(player *Player) (*SessionProfile
 		fallbackPlayer = player.FallbackPlayer
 	}
 
-	for _, fallbackAPIServer := range app.Config.FallbackAPIServers {
+	for _, fallbackAPIServer := range app.FallbackAPIServers {
 		var id string
 		if fallbackPlayerIsUUID {
 			// If we have the UUID already, use it
@@ -695,38 +696,17 @@ func (app *App) GetFallbackSkinTexturesProperty(player *Player) (*SessionProfile
 		} else {
 			// Otherwise, we only know the player name. Query the fallback API
 			// server to get the fallback player's UUID
-			// TODO this should POST /profiles/minecraft instead to be authlib-injector-compatible
-			reqURL, err := url.JoinPath(fallbackAPIServer.AccountURL, "/users/profiles/minecraft/", fallbackPlayer)
-			if err != nil {
-				log.Println(err)
+			lowerName := strings.ToLower(fallbackPlayer)
+			fallbackResponses := fallbackAPIServer.PlayerNamesToIDs(mapset.NewSet(lowerName))
+			if len(fallbackResponses) == 1 && strings.EqualFold(lowerName, fallbackResponses[0].Name) {
+				id = fallbackResponses[0].ID
+			} else {
 				continue
 			}
-			res, err := app.CachedGet(reqURL, fallbackAPIServer.CacheTTLSeconds)
-			if err != nil {
-				log.Printf("Couldn't access fallback API server at %s: %s\n", reqURL, err)
-				continue
-			}
-
-			if res.StatusCode != http.StatusOK {
-				// Be silent, 404s will be common here
-				continue
-			}
-
-			var playerResponse PlayerNameToIDResponse
-			err = json.Unmarshal(res.BodyBytes, &playerResponse)
-			if err != nil {
-				log.Printf("Received invalid response from fallback API server at %s\n", reqURL)
-				continue
-			}
-			id = playerResponse.ID
-		}
-		reqURL, err := url.JoinPath(fallbackAPIServer.SessionURL, "session/minecraft/profile", id)
-		if err != nil {
-			log.Println(err)
-			continue
 		}
 
-		res, err := app.CachedGet(reqURL+"?unsigned=false", fallbackAPIServer.CacheTTLSeconds)
+		reqURL := fallbackAPIServer.Config.SessionURL + "/session/minecraft/profile/" + url.PathEscape(id)
+		res, err := app.CachedGet(reqURL+"?unsigned=false", fallbackAPIServer.Config.CacheTTLSeconds)
 		if err != nil {
 			log.Printf("Couldn't access fallback API server at %s: %s\n", reqURL, err)
 			continue
@@ -806,11 +786,7 @@ func (app *App) GetDefaultSkinTexture(player *Player) *texture {
 		return nil
 	}
 
-	defaultSkinURL, err := url.JoinPath(app.FrontEndURL, "web/texture/default-skin/"+filename)
-	if err != nil {
-		log.Printf("Error generating default skin URL for file %s\n", *defaultSkinPath)
-		return nil
-	}
+	defaultSkinURL := app.FrontEndURL + "/web/texture/default-skin/" + url.PathEscape(filename)
 
 	skinModel := SkinModelClassic
 	if slimSkinRegex.MatchString(*defaultSkinPath) {
@@ -844,11 +820,7 @@ func (app *App) GetDefaultCapeTexture(player *Player) *texture {
 		return nil
 	}
 
-	defaultCapeURL, err := url.JoinPath(app.FrontEndURL, "web/texture/default-cape/"+filename)
-	if err != nil {
-		log.Printf("Error generating default cape URL for file %s\n", *defaultCapePath)
-		return nil
-	}
+	defaultCapeURL := app.FrontEndURL + "/web/texture/default-cape/" + url.PathEscape(filename)
 
 	return &texture{
 		URL: defaultCapeURL,

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ type bodyLimitConfig struct {
 	SizeLimitKiB int
 }
 
-type FallbackAPIServer struct {
+type FallbackAPIServerConfig struct {
 	Nickname         string
 	SessionURL       string
 	AccountURL       string
@@ -114,7 +114,7 @@ type Config struct {
 	EnableBackgroundEffect     bool
 	EnableFooter               bool
 	EnableWebFrontEnd          bool
-	FallbackAPIServers         []FallbackAPIServer
+	FallbackAPIServers         []FallbackAPIServerConfig
 	ForwardSkins               bool
 	InstanceName               string
 	ImportExistingPlayer       importExistingPlayerConfig
@@ -144,6 +144,13 @@ var defaultRateLimitConfig = rateLimitConfig{
 var defaultBodyLimitConfig = bodyLimitConfig{
 	Enable:       true,
 	SizeLimitKiB: 8192,
+}
+
+var DefaultRistrettoConfig = &ristretto.Config{
+	// Defaults from https://pkg.go.dev/github.com/dgraph-io/ristretto#readme-config
+	NumCounters: 1e7,
+	MaxCost:     1 << 30, // 1 GiB
+	BufferItems: 64,
 }
 
 func DefaultConfig() Config {
@@ -190,12 +197,7 @@ func DefaultConfig() Config {
 			Allow:         true,
 			RequireInvite: false,
 		},
-		RequestCache: ristretto.Config{
-			// Defaults from https://pkg.go.dev/github.com/dgraph-io/ristretto#readme-config
-			NumCounters: 1e7,
-			MaxCost:     1 << 30, // 1 GiB
-			BufferItems: 64,
-		},
+		RequestCache:   *DefaultRistrettoConfig,
 		SignPublicKeys: true,
 		SkinSizeLimit:  128,
 		StateDirectory: GetDefaultStateDirectory(),

--- a/config_test.go
+++ b/config_test.go
@@ -92,7 +92,7 @@ func TestConfig(t *testing.T) {
 	assert.NotNil(t, CleanConfig(config))
 
 	config = configTestConfig(sd)
-	testFallbackAPIServer := FallbackAPIServer{
+	testFallbackAPIServer := FallbackAPIServerConfig{
 		Nickname:    "Nickname",
 		SessionURL:  "https://δρασλ.example.com/",
 		AccountURL:  "https://δρασλ.example.com/",
@@ -100,10 +100,10 @@ func TestConfig(t *testing.T) {
 		SkinDomains: []string{"δρασλ.example.com"},
 	}
 	fb := testFallbackAPIServer
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.Nil(t, CleanConfig(config))
 
-	assert.Equal(t, []FallbackAPIServer{{
+	assert.Equal(t, []FallbackAPIServerConfig{{
 		Nickname:    fb.Nickname,
 		SessionURL:  "https://xn--mxafwwl.example.com",
 		AccountURL:  "https://xn--mxafwwl.example.com",
@@ -113,37 +113,37 @@ func TestConfig(t *testing.T) {
 
 	fb = testFallbackAPIServer
 	fb.Nickname = ""
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.NotNil(t, CleanConfig(config))
 
 	fb = testFallbackAPIServer
 	fb.SessionURL = ""
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.NotNil(t, CleanConfig(config))
 
 	fb = testFallbackAPIServer
 	fb.SessionURL = ":invalid URL"
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.NotNil(t, CleanConfig(config))
 
 	fb = testFallbackAPIServer
 	fb.AccountURL = ""
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.NotNil(t, CleanConfig(config))
 
 	fb = testFallbackAPIServer
 	fb.AccountURL = ":invalid URL"
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.NotNil(t, CleanConfig(config))
 
 	fb = testFallbackAPIServer
 	fb.ServicesURL = ""
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.NotNil(t, CleanConfig(config))
 
 	fb = testFallbackAPIServer
 	fb.ServicesURL = ":invalid URL"
-	config.FallbackAPIServers = []FallbackAPIServer{fb}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{fb}
 	assert.NotNil(t, CleanConfig(config))
 
 	// Test that TEMPLATE_CONFIG_FILE is valid

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
           ];
 
           # Update whenever Go dependencies change
-          vendorHash = "sha256-jthuA1MlP83sXYuZHX6MwD33JfhjrFPax5B+26iLh20=";
+          vendorHash = "sha256-iGOYsgrOwx3nbvlc3ln6awg23CZBdtaqQbYY30q25dU=";
 
           outputs = ["out"];
 

--- a/front_test.go
+++ b/front_test.go
@@ -44,7 +44,7 @@ func setupRegistrationExistingPlayerTS(t *testing.T, requireSkinVerification boo
 		AccountURL:              ts.AuxApp.AccountURL,
 		RequireSkinVerification: requireSkinVerification,
 	}
-	config.FallbackAPIServers = []FallbackAPIServer{
+	config.FallbackAPIServers = []FallbackAPIServerConfig{
 		{
 			Nickname:    "Aux",
 			SessionURL:  ts.AuxApp.SessionURL,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.2
 
 require (
 	github.com/BurntSushi/toml v1.3.2
-	github.com/deckarep/golang-set/v2 v2.6.0
+	github.com/deckarep/golang-set/v2 v2.8.0
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
-github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
+github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
+github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
 github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=

--- a/main.go
+++ b/main.go
@@ -367,6 +367,7 @@ func (app *App) MakeServer() *echo.Echo {
 	e.POST("/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/publickeys", servicesPublicKeys)
+	e.GET("/minecraft/profile/lookup/name/:playerName", accountPlayerNameToID)
 	e.POST("/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
 	e.GET("/services/privileges", servicesPlayerAttributes)
@@ -382,6 +383,7 @@ func (app *App) MakeServer() *echo.Echo {
 	e.POST("/services/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/services/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/services/publickeys", servicesPublicKeys)
+	e.GET("/services/minecraft/profile/lookup/name/:playerName", accountPlayerNameToID)
 	e.POST("/services/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
 	e.GET("/authlib-injector/minecraftservices/privileges", servicesPlayerAttributes)
@@ -397,6 +399,7 @@ func (app *App) MakeServer() *echo.Echo {
 	e.POST("/authlib-injector/minecraftservices/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/authlib-injector/minecraftservices/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/authlib-injector/minecraftservices/publickeys", servicesPublicKeys)
+	e.GET("/authlib-injector/minecraftservices/minecraft/profile/lookup/name/:playerName", accountPlayerNameToID)
 	e.POST("/authlib-injector/minecraftservices/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
 	return e

--- a/main.go
+++ b/main.go
@@ -612,7 +612,7 @@ func setup(config *Config) *App {
 
 func (app *App) Run() {
 	for _, fallbackAPIServer := range PtrSlice(app.FallbackAPIServers) {
-		go (*fallbackAPIServer).PlayerNamesToIDsWorker()
+		go app.PlayerNamesToIDsWorker(fallbackAPIServer)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"sync"
 	"time"
 )
 
@@ -53,7 +52,8 @@ type App struct {
 	SessionURL               string
 	AuthlibInjectorURL       string
 	DB                       *gorm.DB
-	FSMutex                  KeyedMutex
+	GetURLMutex              *KeyedMutex
+	FSMutex                  *KeyedMutex
 	RequestCache             *ristretto.Cache
 	Config                   *Config
 	TransientUsernameRegex   *regexp.Regexp
@@ -65,7 +65,6 @@ type App struct {
 	PrivateKeyB3Sum256       [256 / 8]byte
 	PrivateKeyB3Sum512       [512 / 8]byte
 	AEAD                     cipher.AEAD
-	SkinMutex                *sync.Mutex
 	VerificationSkinTemplate *image.NRGBA
 	OIDCProviderNames        []string
 	OIDCProvidersByName      map[string]*OIDCProvider
@@ -550,7 +549,8 @@ func setup(config *Config) *App {
 		ValidPlayerNameRegex:     validPlayerNameRegex,
 		Constants:                Constants,
 		DB:                       db,
-		FSMutex:                  KeyedMutex{},
+		FSMutex:                  &KeyedMutex{},
+		GetURLMutex:              &KeyedMutex{},
 		PrivateKey:               key,
 		PrivateKeyB3Sum256:       keyB3Sum256,
 		PrivateKeyB3Sum512:       keyB3Sum512,

--- a/main.go
+++ b/main.go
@@ -353,6 +353,7 @@ func (app *App) MakeServer() *echo.Echo {
 	servicesUploadSkin := ServicesUploadSkin(app)
 	servicesChangeName := ServicesChangeName(app)
 	servicesPublicKeys := ServicesPublicKeys(app)
+	servicesIDToPlayerName := app.ServicesIDToPlayerName()
 
 	e.GET("/privileges", servicesPlayerAttributes)
 	e.GET("/player/attributes", servicesPlayerAttributes)
@@ -367,6 +368,7 @@ func (app *App) MakeServer() *echo.Echo {
 	e.POST("/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/publickeys", servicesPublicKeys)
+	e.GET("/minecraft/profile/lookup/:id", servicesIDToPlayerName)
 	e.GET("/minecraft/profile/lookup/name/:playerName", accountPlayerNameToID)
 	e.POST("/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
@@ -383,6 +385,7 @@ func (app *App) MakeServer() *echo.Echo {
 	e.POST("/services/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/services/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/services/publickeys", servicesPublicKeys)
+	e.GET("/services/minecraft/profile/lookup/:id", servicesIDToPlayerName)
 	e.GET("/services/minecraft/profile/lookup/name/:playerName", accountPlayerNameToID)
 	e.POST("/services/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 
@@ -399,6 +402,7 @@ func (app *App) MakeServer() *echo.Echo {
 	e.POST("/authlib-injector/minecraftservices/minecraft/profile/skins", servicesUploadSkin)
 	e.PUT("/authlib-injector/minecraftservices/minecraft/profile/name/:playerName", servicesChangeName)
 	e.GET("/authlib-injector/minecraftservices/publickeys", servicesPublicKeys)
+	e.GET("/authlib-injector/minecraftservices/minecraft/profile/lookup/:id", servicesIDToPlayerName)
 	e.GET("/authlib-injector/minecraftservices/minecraft/profile/lookup/name/:playerName", accountPlayerNameToID)
 	e.POST("/authlib-injector/minecraftservices/minecraft/profile/lookup/bulk/byname", accountPlayerNamesToIDs)
 

--- a/model.go
+++ b/model.go
@@ -86,6 +86,26 @@ func IDToUUID(id string) (string, error) {
 	return id[0:8] + "-" + id[8:12] + "-" + id[12:16] + "-" + id[16:20] + "-" + id[20:], nil
 }
 
+func ParseUUID(idOrUUID string) (string, error) {
+	if len(idOrUUID) == 32 {
+		uuid_, err := IDToUUID(idOrUUID)
+		if err != nil {
+			return "", err
+		}
+		if _, err := uuid.Parse(uuid_); err != nil {
+			return "", err
+		}
+		return uuid_, nil
+	}
+	if len(idOrUUID) == 36 {
+		if _, err := uuid.Parse(idOrUUID); err != nil {
+			return "", err
+		}
+		return idOrUUID, nil
+	}
+	return "", errors.New("invalid ID or UUID")
+}
+
 func (app *App) ValidatePlayerName(playerName string) error {
 	if app.TransientLoginEligible(playerName) {
 		return errors.New("name is reserved for transient login")

--- a/player.go
+++ b/player.go
@@ -398,7 +398,7 @@ func (app *App) ValidateChallenge(playerName string, challengeToken *string) (*P
 		return nil, errors.New("registration server returned error")
 	}
 
-	var idRes playerNameToUUIDResponse
+	var idRes PlayerNameToIDResponse
 	err = json.NewDecoder(res.Body).Decode(&idRes)
 	if err != nil {
 		return nil, err

--- a/services_test.go
+++ b/services_test.go
@@ -27,7 +27,7 @@ func TestServices(t *testing.T) {
 
 		config := testConfig()
 		config.ForwardSkins = false
-		config.FallbackAPIServers = []FallbackAPIServer{
+		config.FallbackAPIServers = []FallbackAPIServerConfig{
 			{
 				Nickname:    "Aux",
 				SessionURL:  ts.AuxApp.SessionURL,
@@ -502,7 +502,7 @@ func (ts *TestSuite) makeTestAccountPlayerNamesToIDs(url string) func(t *testing
 		ts.Server.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
-		var response []playerNameToUUIDResponse
+		var response []PlayerNameToIDResponse
 		assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
 
 		// Get the real UUID
@@ -513,6 +513,6 @@ func (ts *TestSuite) makeTestAccountPlayerNamesToIDs(url string) func(t *testing
 		assert.Nil(t, err)
 
 		// There should only be one user, the nonexistent user should not be present
-		assert.Equal(t, []playerNameToUUIDResponse{{Name: TEST_USERNAME, ID: id}}, response)
+		assert.Equal(t, []PlayerNameToIDResponse{{Name: TEST_USERNAME, ID: id}}, response)
 	}
 }

--- a/test_suite_test.go
+++ b/test_suite_test.go
@@ -90,8 +90,10 @@ func (ts *TestSuite) Setup(config *Config) {
 	tsConfig := *config
 	ts.Config = &tsConfig
 	ts.App = setup(config)
-	ts.Server = ts.App.MakeServer()
 
+	go ts.App.Run()
+
+	ts.Server = ts.App.MakeServer()
 	go func() { Ignore(ts.Server.Start("")) }()
 }
 
@@ -105,8 +107,10 @@ func (ts *TestSuite) SetupAux(config *Config) {
 	auxConfig := *config
 	ts.AuxConfig = &auxConfig
 	ts.AuxApp = setup(config)
-	ts.AuxServer = ts.AuxApp.MakeServer()
 
+	go ts.AuxApp.Run()
+
+	ts.AuxServer = ts.AuxApp.MakeServer()
 	go func() { Ignore(ts.AuxServer.Start("")) }()
 
 	// Wait until the server has a listen address... polling seems like the
@@ -127,13 +131,13 @@ func (ts *TestSuite) SetupAux(config *Config) {
 	ts.AuxApp.SessionURL = Unwrap(url.JoinPath(baseURL, "session"))
 }
 
-func (ts *TestSuite) ToFallbackAPIServer(app *App, nickname string) FallbackAPIServer {
-	return FallbackAPIServer{
+func (ts *TestSuite) ToFallbackAPIServer(app *App, nickname string) FallbackAPIServerConfig {
+	return FallbackAPIServerConfig{
 		Nickname:        nickname,
 		SessionURL:      app.SessionURL,
 		AccountURL:      app.AccountURL,
 		ServicesURL:     app.ServicesURL,
-		CacheTTLSeconds: 3600,
+		CacheTTLSeconds: 0,
 	}
 }
 
@@ -324,7 +328,7 @@ func testConfig() *Config {
 	config.Domain = "drasl.example.com"
 	noRateLimit := rateLimitConfig{Enable: false}
 	config.RateLimit = noRateLimit
-	config.FallbackAPIServers = []FallbackAPIServer{}
+	config.FallbackAPIServers = []FallbackAPIServerConfig{}
 	config.LogRequests = false
 	return &config
 }


### PR DESCRIPTION
This implements something similar to https://github.com/elyby/chrly/issues/1 to work around rate-limiting of https://api.mojang.com/profiles/minecraft.

We now have a per-fallback-server cache of lowercase player name -> UUID, so something like `POST ["notch", "herobrine"]` then `POST ["notch"]` within the `FallbackAPIServer.CacheTTLSeconds` window will only result in one request.

We send batches of 10 player names to the fallback API server (often https://api.mojang.com/profiles/minecraft) at a time. Sending more will result in `CONSTRAINT_VIOLATION`, `getProfileName.profileNames: size must be between 0 and 10`. We wait at least 1 second between requests to this route (more research into the precise rate limits may be needed in the future. Are we rate-limited per API route or is there one rate limit for all of api.mojang.com?).

Other requests to fallback API servers are now cached more smartwise. If two requests to the same fallback server URL are initiated at the same time, one will wait for the other to finish and skip the duplicate request if the response was cached.

This also implements `/minecraft/profile/lookup/name/:playerName` and `/minecraft/profile/lookup/:id` which seem to have been [recently added by Mojang](https://minecraft.wiki/w/Mojang_API?diff=prev&oldid=2820994).