### PR TITLE
Fix user template call to include target user's username

### DIFF
--- a/view/user.tmpl
+++ b/view/user.tmpl
@@ -87,7 +87,7 @@
   {{ else }}
     {{ call .T "No players yet." }}
   {{ end }}
-  <p>{{ if or (and (not .User.IsAdmin) (not .App.Config.AllowAddingDeletingPlayers)) (eq .MaxPlayerCount 0) }}
+  <p>{{ if or (and (not .TargetUser.IsAdmin) (not .App.Config.AllowAddingDeletingPlayers)) (eq .MaxPlayerCount 0) }}
       {{ if .AdminView }}
         {{ call .T
           "%s is not allowed to add new players. You can override this limit since you're an admin."
@@ -110,7 +110,6 @@
           "You are only allowed to have %d player."
           "You are allowed to have up to %d players."
           .MaxPlayerCount
-          .TargetUser.Username
           .MaxPlayerCount
         }}
       {{ end }}


### PR DESCRIPTION
before:
<img width="558" height="168" alt="Screenshot_20251013_200946" src="https://github.com/user-attachments/assets/c591748c-372d-4684-b185-c83d720cc3a5" />
after:
<img width="597" height="165" alt="Screenshot_20251013_200905" src="https://github.com/user-attachments/assets/59bd9b8c-86a5-474d-be6f-5fb50be60db7" />
