### PR TITLE
1.21.9+ support

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -60,6 +60,7 @@ These instructions assume familiarity with the command line and are written for 
      -Dminecraft.api.env=custom \
      -Dminecraft.api.auth.host=https://drasl.example.com/auth \
      -Dminecraft.api.account.host=https://drasl.example.com/account \
+     -Dminecraft.api.profiles.host=https://drasl.example.com/profiles \
      -Dminecraft.api.session.host=https://drasl.example.com/session \
      -Dminecraft.api.services.host=https://drasl.example.com/services \
      -javaagent:ProxyFix-1.0-SNAPSHOT-jar-with-dependencies.jar \

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -103,6 +103,7 @@ On recent versions of Minecraft, you can use Drasl on an unmodified Vanilla serv
 -Dminecraft.api.env=custom
 -Dminecraft.api.auth.host=https://drasl.example.com/auth
 -Dminecraft.api.account.host=https://drasl.example.com/account
+-Dminecraft.api.profiles.host=https://drasl.example.com/profiles
 -Dminecraft.api.session.host=https://drasl.example.com/session
 -Dminecraft.api.services.host=https://drasl.example.com/services
 ```
@@ -114,6 +115,7 @@ java -Xmx1024M -Xms1024M \
     -Dminecraft.api.env=custom \
     -Dminecraft.api.auth.host=https://drasl.example.com/auth \
     -Dminecraft.api.account.host=https://drasl.example.com/account \
+    -Dminecraft.api.profiles.host=https://drasl.example.com/profiles \
     -Dminecraft.api.session.host=https://drasl.example.com/session \
     -Dminecraft.api.services.host=https://drasl.example.com/services \
     -jar server.jar nogui
@@ -134,6 +136,7 @@ java -Xmx1024M -Xms1024M \
     -Dminecraft.api.env=custom \
     -Dminecraft.api.auth.host=https://drasl.example.com/auth \
     -Dminecraft.api.account.host=https://drasl.example.com/account \
+    -Dminecraft.api.profiles.host=https://drasl.example.com/profiles \
     -Dminecraft.api.session.host=https://drasl.example.com/session \
     -Dminecraft.api.services.host=https://drasl.example.com/services \
 	-Djava.protocol.handler.pkgs=gg.codie.mineonline.protocol \

--- a/main.go
+++ b/main.go
@@ -319,6 +319,10 @@ func (app *App) MakeServer() *echo.Echo {
 	e.GET("/account/users/profiles/minecraft/:playerName", accountPlayerNameToID)
 	e.POST("/account/profiles/minecraft", accountPlayerNamesToIDs)
 
+	e.GET("/profiles/user/security/location", accountVerifySecurityLocation)
+	e.GET("/profiles/users/profiles/minecraft/:playerName", accountPlayerNameToID)
+	e.POST("/profiles/profiles/minecraft", accountPlayerNamesToIDs)
+
 	e.GET("/authlib-injector/api/user/security/location", accountVerifySecurityLocation)
 	e.GET("/authlib-injector/api/users/profiles/minecraft/:playerName", accountPlayerNameToID)
 	e.POST("/authlib-injector/api/profiles/minecraft", accountPlayerNamesToIDs)

--- a/view/root.tmpl
+++ b/view/root.tmpl
@@ -121,6 +121,7 @@
 -Dminecraft.api.env=custom
 -Dminecraft.api.auth.host={{ .App.AuthURL }}
 -Dminecraft.api.account.host={{ .App.AccountURL }}
+-Dminecraft.api.profiles.host={{ .App.AccountURL }}
 -Dminecraft.api.session.host={{ .App.SessionURL }}
 -Dminecraft.api.services.host={{ .App.ServicesURL }}</pre>
 
@@ -130,6 +131,7 @@ java -Xmx1024M -Xms1024M \
     -Dminecraft.api.env=custom \
     -Dminecraft.api.auth.host={{ .App.AuthURL }} \
     -Dminecraft.api.account.host={{ .App.AccountURL }} \
+    -Dminecraft.api.profiles.host={{ .App.AccountURL }} \
     -Dminecraft.api.session.host={{ .App.SessionURL }} \
     -Dminecraft.api.services.host={{ .App.ServicesURL }} \
     -jar server.jar nogui</pre>


### PR DESCRIPTION
In minecraft 1.21.9, `minecraft.api.account.host` was renamed to `minecraft.api.profiles.host`

- Create .App.ProfilesURL for use in root.tmpl
- Add `minecraft.api.profiles.host` to documentation and root.tmpl
- Add /profiles endpoint as an alias of /account endpoint