### PR TITLE
Remove uploadableTextures from fullProfile

### DIFF
--- a/main.go
+++ b/main.go
@@ -314,7 +314,7 @@ func (app *App) MakeServer() *echo.Echo {
 	sessionCheckServer := SessionCheckServer(app)
 	sessionJoin := SessionJoin(app)
 	sessionJoinServer := SessionJoinServer(app)
-	sessionProfile := SessionProfile(app, false)
+	sessionProfile := SessionProfile(app)
 	sessionBlockedServers := SessionBlockedServers(app)
 	for _, prefix := range []string{"", "/session", "/authlib-injector/sessionserver"} {
 		e.GET(prefix+"/session/minecraft/hasJoined", sessionHasJoined)

--- a/session.go
+++ b/session.go
@@ -98,7 +98,7 @@ func SessionJoinServer(app *App) func(c echo.Context) error {
 	}
 }
 
-func fullProfile(app *App, user *User, player *Player, uuid string, sign bool, fromAuthlibInjector bool) (SessionProfileResponse, error) {
+func fullProfile(app *App, user *User, player *Player, uuid string, sign bool) (SessionProfileResponse, error) {
 	id, err := UUIDToID(uuid)
 	if err != nil {
 		return SessionProfileResponse{}, err
@@ -176,7 +176,7 @@ func (app *App) hasJoined(c *echo.Context, playerName string, serverID string, l
 		return (*c).String(http.StatusOK, "YES")
 	}
 
-	profile, err := fullProfile(app, &user, &player, player.UUID, true, false)
+	profile, err := fullProfile(app, &user, &player, player.UUID, true)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func SessionCheckServer(app *App) func(c echo.Context) error {
 
 // /session/minecraft/profile/:id
 // https://minecraft.wiki/w/Mojang_API#Query_player's_skin_and_cape
-func SessionProfile(app *App, fromAuthlibInjector bool) func(c echo.Context) error {
+func SessionProfile(app *App) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		id := c.Param("id")
 		uuid_, err := ParseUUID(id)
@@ -238,7 +238,7 @@ func SessionProfile(app *App, fromAuthlibInjector bool) func(c echo.Context) err
 		}
 
 		sign := c.QueryParam("unsigned") == "false"
-		profile, err := fullProfile(app, user, player, uuid_, sign, fromAuthlibInjector)
+		profile, err := fullProfile(app, user, player, uuid_, sign)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As far as I'm aware, authlib-injector does not use this anywhere. I'd like if it were removed because in ReIndev, a popular b1.7.3 mod, it attempts to base64 decode every "value" field in `properties`. Under Mojang authentication server it succeeds, but with drasl it will try to Base64-decode something like "skin,cape" and fail.