### PR TITLE
nix: fixed trace warning about pkgs.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,7 +131,7 @@
         {
           options.services.drasl = {
             enable = mkEnableOption (lib.mdDoc ''drasl'');
-            package = mkPackageOption { drasl = self.defaultPackage.${pkgs.system}; } "drasl" { };
+            package = mkPackageOption { drasl = self.defaultPackage.${pkgs.stdenv.hostPlatform.system}; } "drasl" { };
             settings = mkOption {
               type = format.type;
               default = { };


### PR DESCRIPTION
Fixes trace warning

> trace: evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
