### PR TITLE
Drop legacy routes

### DIFF
--- a/build_config.go
+++ b/build_config.go
@@ -2,7 +2,7 @@ package main
 
 // Build constants
 
-const VERSION = "3.4.4"
+const VERSION = "4.0.0"
 
 const REPOSITORY_URL = "https://github.com/unmojang/drasl"
 const SWAGGER_UI_URL = "https://doc.drasl.unmojang.org"

--- a/main.go
+++ b/main.go
@@ -391,24 +391,20 @@ func (app *App) MakeServer() *echo.Echo {
 
 	// Session
 	sessionHasJoined := SessionHasJoined(app)
-	sessionCheckServer := SessionCheckServer(app)
 	sessionJoin := SessionJoin(app)
-	sessionJoinServer := SessionJoinServer(app)
 	sessionProfile := SessionProfile(app, false)
 	sessionBlockedServers := SessionBlockedServers(app)
 	sessionHeartbeat := SessionHeartbeat(app)
 	sessionGetMpPass := SessionGetMpPass(app)
 	for _, prefix := range []string{"", "/session", "/authlib-injector/sessionserver"} {
-		// Unauthenticated hasJoined routes should probably not be rate limited since they are called very frequently by Minecraft servers
+		// Unauthenticated hasJoined route should probably not be rate limited since it is called very frequently by Minecraft servers
 		base.GET(prefix+"/session/minecraft/hasJoined", sessionHasJoined)
-		base.GET(prefix+"/game/checkserver.jsp", sessionCheckServer)
 
 		rateLimitedUnauthenticated.GET(prefix+"/session/minecraft/profile/:id", sessionProfile)
 		rateLimitedUnauthenticated.GET(prefix+"/blockedservers", sessionBlockedServers)
 
 		// Perform authentication first in Bind*, then rate limit
 		base.POST(prefix+"/session/minecraft/join", sessionJoin, app.BindSessionJoin(), rateLimiter)
-		base.GET(prefix+"/game/joinserver.jsp", sessionJoinServer, app.BindSessionJoinServer(), rateLimiter)
 
 		// Classic protocol routes
 		rateLimitedUnauthenticated.Any(prefix+"/heartbeat.jsp", sessionHeartbeat)

--- a/session.go
+++ b/session.go
@@ -88,82 +88,6 @@ func SessionJoin(app *App) func(c *echo.Context) error {
 	}
 }
 
-// Perform request validation and authentication for SessionJoinServer
-func (app *App) BindSessionJoinServer() func(echo.HandlerFunc) echo.HandlerFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c *echo.Context) error {
-			playerName := c.QueryParam("user")
-			sessionID := c.QueryParam("sessionId")
-
-			if playerName == "" {
-				return c.String(http.StatusOK, "Bad login")
-			}
-
-			// Parse sessionId. It has the form:
-			// token:<accessToken>:<player UUID>
-			split := strings.Split(sessionID, ":")
-			if len(split) != 3 || split[0] != "token" {
-				return c.String(http.StatusOK, "Bad login")
-			}
-			accessToken := split[1]
-			id := split[2]
-
-			// Is the accessToken valid?
-			client, err := app.GetClient(accessToken, mo.None[string](), StalePolicyDeny, true)
-			if err != nil {
-				var userError *UserError
-				if errors.As(err, &userError) {
-					return c.String(http.StatusOK, "Bad login")
-				} else {
-					return err
-				}
-
-			}
-
-			// If the player name corresponding to the access token doesn't match
-			// the `user` param from the request, return NO
-			player := client.Player
-			if player.Name != playerName {
-				return c.String(http.StatusOK, "Bad login")
-			}
-			// If the player's UUID doesn't match the UUID in the sessionId, return
-			// NO
-			playerID, err := UUIDToID(player.UUID)
-			if err != nil {
-				return err
-			}
-			if playerID != id {
-				return c.String(http.StatusOK, "Bad login")
-			}
-
-			maybeUser := mo.Some(client.User)
-			maybePlayer := mo.Some(*client.Player)
-			c.Set(CONTEXT_KEY_CLIENT, client)
-			c.Set(CONTEXT_KEY_MAYBE_USER, maybeUser)
-			c.Set(CONTEXT_KEY_USER, maybeUser.ToPointer())
-			c.Set(CONTEXT_KEY_MAYBE_PLAYER, maybePlayer)
-			c.Set(CONTEXT_KEY_PLAYER, maybePlayer.ToPointer())
-			return next(c)
-		}
-	}
-}
-
-// /game/joinserver.jsp
-func SessionJoinServer(app *App) func(c *echo.Context) error {
-	return func(c *echo.Context) error {
-		player := c.Get(CONTEXT_KEY_PLAYER).(*Player)
-		serverID := c.QueryParam("serverId")
-
-		player.ServerID = MakeNullString(&serverID)
-		result := app.DB.Save(&player)
-		if result.Error != nil {
-			return result.Error
-		}
-
-		return c.String(http.StatusOK, "OK")
-	}
-}
-
 func fullProfile(app *App, user *User, player *Player, uuid string, sign bool, fromAuthlibInjector bool) (SessionProfileResponse, error) {
 	id, err := UUIDToID(uuid)
 	if err != nil {
@@ -271,15 +195,6 @@ func SessionHasJoined(app *App) func(c *echo.Context) error {
 		playerName := c.QueryParam("username")
 		serverID := c.QueryParam("serverId")
 		return app.hasJoined(c, playerName, serverID, false)
-	}
-}
-
-// /game/checkserver.jsp
-func SessionCheckServer(app *App) func(c *echo.Context) error {
-	return func(c *echo.Context) error {
-		playerName := c.QueryParam("user")
-		serverID := c.QueryParam("serverId")
-		return app.hasJoined(c, playerName, serverID, true)
 	}
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -57,14 +57,6 @@ func (ts *TestSuite) testSessionJoin(t *testing.T) {
 		assert.Equal(t, serverID, *UnmakeNullString(&player.ServerID))
 	}
 	{
-		// Successful joinserver.jsp
-		sessionID := "token:" + accessToken + ":" + selectedProfile
-		rec := ts.Get(t, ts.Server, "/game/joinserver.jsp?user="+TEST_PLAYER_NAME+"&sessionId="+sessionID+"&serverId="+serverID, nil, nil)
-
-		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "OK", rec.Body.String())
-	}
-	{
 		// Join should fail if we send an invalid access token
 
 		// Start with an invalid ServerID
@@ -83,25 +75,6 @@ func (ts *TestSuite) testSessionJoin(t *testing.T) {
 		var response YggdrasilErrorResponse
 		assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
 		assert.Equal(t, "ForbiddenOperationException", *response.Error)
-
-		// Player ServerID should be invalid
-		assert.Nil(t, ts.App.DB.First(&player, "name = ?", TEST_PLAYER_NAME).Error)
-		assert.False(t, player.ServerID.Valid)
-	}
-	{
-		// "Bad login" with invalid access token
-
-		// Start with an invalid ServerID
-		assert.Nil(t, ts.App.DB.First(&player, "name = ?", TEST_PLAYER_NAME).Error)
-		player.ServerID = MakeNullString(nil)
-		assert.Nil(t, ts.App.DB.Save(&player).Error)
-
-		accessToken := "invalid"
-		sessionID := "token:" + accessToken + ":" + selectedProfile
-		rec := ts.Get(t, ts.Server, "/game/joinserver.jsp?user="+TEST_PLAYER_NAME+"&sessionId="+sessionID+"&serverId="+serverID, nil, nil)
-
-		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "Bad login", rec.Body.String())
 
 		// Player ServerID should be invalid
 		assert.Nil(t, ts.App.DB.First(&player, "name = ?", TEST_PLAYER_NAME).Error)
@@ -133,14 +106,6 @@ func (ts *TestSuite) testSessionHasJoined(t *testing.T) {
 		assert.Equal(t, player.Name, response.Name)
 	}
 	{
-		// Successful checkserver.jsp
-
-		url := "/game/checkserver.jsp?user=" + player.Name + "&serverId=" + serverID
-		rec := ts.Get(t, ts.Server, url, nil, nil)
-		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "YES", rec.Body.String())
-	}
-	{
 		// hasJoined should fail if we send an invalid server ID
 
 		// Start with a valid ServerID
@@ -151,15 +116,6 @@ func (ts *TestSuite) testSessionHasJoined(t *testing.T) {
 		url := "/session/minecraft/hasJoined?username=" + player.Name + "&serverId=" + "invalid" + "&ip=" + "127.0.0.1"
 		rec := ts.Get(t, ts.Server, url, nil, nil)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
-	}
-	{
-		// Unsuccessful checkserver.jsp
-
-		invalidServerID := "INVALID-SERVER-ID"
-		url := "/game/checkserver.jsp?user=" + player.Name + "&serverId=" + invalidServerID
-		rec := ts.Get(t, ts.Server, url, nil, nil)
-		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "NO", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
Nothing is to my knowledge using these drasl-specific joinserver.jsp and checkserver,jsp APIs, Loki/OnlineModeFix and so on are using the modern join and hasJoined APIs. There is even flaws with the implementation as compared to how Mojang did it, see #243. I think it would be a better idea to drop this entirely, and let Loki/OnlineModeFix handle this as they do already.