### PR TITLE
improve the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,42 @@
+# ==============================================================================
+# GLOBAL VARIABLES & KERNEL-LEVEL ENVIRONMENT INJECTION
+# ==============================================================================
 prefix ?= /usr
 .DEFAULT_GOAL := build
 
-# TODO probably use `go tool` for this eventually
+# FIX: Elevate env vars to global Make variables to guarantee injection into the Go toolchain process tree
+export GOFLAGS     := -buildmode=pie
+export CGO_CPPFLAGS := -D_FORTIFY_SOURCE=3
+export CGO_LDFLAGS  := -Wl,-z,relro,-z,now
+
+# Dynamically resolve the path of the swag toolchain
 SWAG := $(shell command -v swag || echo 'go run github.com/swaggo/swag/cmd/swag@v1.16.4')
 
-npm-install:
+# ==============================================================================
+# EXPLICIT PHONY TARGETS DECLARATION (Prevents collisions with physical entities)
+# ==============================================================================
+.PHONY: build prebuild swag npm-install clean test install
+
+# ==============================================================================
+# BUILD ROUTING TOPO-MATRIX
+# ==============================================================================
+
+# PERFORMANCE OPTIMIZATION: Implement file-timestamp-based dependency tracking
+# Triggers 'npm install' only when package.json mutates, mitigating redundant disk I/O
+node_modules: package.json
 	npm install
 
-swag:
-	$(SWAG) init --generalInfo api.go --output ./assets/ --outputTypes json
+npm-install: node_modules
 
-prebuild: npm-install swag
+swag:
+	$(SWAG) init --generalInfo api.go --output ./assets/ --outputTypes json --exclude node_modules
+
+# Abstract the asset bundling stage as a pre-requisite state
+prebuild: node_modules swag
 	node esbuild.config.js
 
+# Compilation boundary: 'go build' now securely inherits PIE & RELRO hardening parameters
 build: prebuild
-	export GOFLAGS='-buildmode=pie'
-	export CGO_CPPFLAGS="-D_FORTIFY_SOURCE=3"
-	export CGO_LDFLAGS="-Wl,-z,relro,-z,now"
 	go build
 
 install: build
@@ -29,6 +49,7 @@ clean:
 	rm -f drasl
 	rm -f swagger.json
 	rm -f public/bundle.js
+	rm -rf node_modules  # Deep purge of localized node artifacts
 
 test: prebuild
 	go test


### PR DESCRIPTION
### 🚀 Refactor(makefile): Fix environment variable scoping and add `.PHONY` definitions

#### 1. Root Cause & Fault Isolation
* **Environment Leakage**: In the previous recipe for the `build` target, `export` was executed inside individual shell invocations. Since GNU Make spawns a separate sub-process for each recipe line, the exported flags (`GOFLAGS`, `CGO_CPPFLAGS`, `CGO_LDFLAGS`) collapsed immediately upon sub-process termination. Consequently, the actual `go build` process ran without security-hardening parameters (`PIE`, `RELRO`, `FORTIFY_SOURCE=3`).
* **Namespace Collision Risk**: The absence of explicit `.PHONY` declarations created a structural deadlock. If a physical directory or file named `test`, `clean`, or `swag` was present in the workspace, Make would bypass the recipes due to implicit rule evaluations.

#### 2. Architectural Modifications
* **Global Scoping**: Elevated the compilation flags to global Make variables, ensuring full propagation down the inherited process environment array (`envp[]`).
* **Deterministic Build State**: Declared all abstract targets under `.PHONY` to guarantee idempotency across varying host filesystems.
* **I/O Optimization**: Restructured `node_modules` targeting as a conditional dependency bound to `package.json`'s modification timestamp, pruning redundant disk evaluations during iterative testing.
