### PR TITLE
Fallback pubkeys improvements

### DIFF
--- a/account.go
+++ b/account.go
@@ -181,8 +181,8 @@ func (app *App) PlayerNamesToIDsWorker(fallbackAPIServer *FallbackAPIServer) {
 					responseCh <- mo.None[PlayerNameToIDResponse]()
 				}
 			}
+			delete(lowerNameToResponseChs, *lowerName)
 		}
-		clear(lowerNameToResponseChs)
 	}
 }
 

--- a/account_test.go
+++ b/account_test.go
@@ -3,9 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/dgraph-io/ristretto"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/assert"
 	"net/http"
+	"net/http/httptest"
+	"regexp"
 	"testing"
+	"time"
 )
 
 func TestAccount(t *testing.T) {
@@ -43,6 +48,81 @@ func TestAccount(t *testing.T) {
 
 		t.Run("Test /users/profiles/minecraft/:playerName, fallback API server", ts.testAccountPlayerNameToIDFallback)
 		t.Run("Test /profile/minecraft, fallback API server", ts.testAccountPlayerNamesToIDsFallback)
+	}
+}
+
+func TestFallbackPlayerNamesToIDsConcurrentBatches(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var names []string
+		if err := json.NewDecoder(r.Body).Decode(&names); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		responses := make([]PlayerNameToIDResponse, 0, len(names))
+		for _, name := range names {
+			responses = append(responses, PlayerNameToIDResponse{
+				ID:   "00000000000000000000000000000001",
+				Name: name,
+			})
+		}
+		_ = json.NewEncoder(w).Encode(responses)
+	}))
+	defer upstream.Close()
+
+	fallbackConfig := defaultFallbackAPIServer()
+	fallbackConfig.CacheTTLSeconds = 0
+	fallback := &FallbackAPIServer{
+		Config:                   &fallbackConfig,
+		PlayerNameToIDCache:      mo.None[*ristretto.Cache](),
+		PlayerNameToIDJobCh:      make(chan []playerNameToIDJob),
+		ProfilesGetManyByNameURL: upstream.URL,
+		PlayerNameValidator: PlayerNameValidator{
+			ValidPlayerNameRegex: regexp.MustCompile(DEFAULT_VALID_PLAYER_NAME_REGEX),
+			MinPlayerNameLength:  DEFAULT_MIN_PLAYER_NAME_LENGTH,
+			MaxPlayerNameLength:  DEFAULT_MAX_PLAYER_NAME_LENGTH,
+		},
+	}
+	go (&App{}).PlayerNamesToIDsWorker(fallback)
+
+	const primeName = "primeuser"
+	names := make([]string, 0, 2*MAX_PLAYER_NAMES_TO_IDS)
+	for i := 0; i < 2*MAX_PLAYER_NAMES_TO_IDS; i++ {
+		name := fmt.Sprintf("batchuser%02d", i)
+		names = append(names, name)
+	}
+
+	primeReturnCh := make(chan mo.Option[PlayerNameToIDResponse], 1)
+	fallback.PlayerNameToIDJobCh <- []playerNameToIDJob{{LowerName: primeName, ReturnCh: primeReturnCh}}
+	primeResponse, ok := (<-primeReturnCh).Get()
+	assert.True(t, ok)
+	assert.Equal(t, primeName, primeResponse.Name)
+
+	jobs := make([]playerNameToIDJob, 0, len(names))
+	for _, name := range names {
+		jobs = append(jobs, playerNameToIDJob{
+			LowerName: name,
+			ReturnCh:  make(chan mo.Option[PlayerNameToIDResponse], 1),
+		})
+	}
+
+	// The priming request starts the throttle interval. Queue two full batches
+	// during that interval so the worker must retain the second batch's channels.
+	fallback.PlayerNameToIDJobCh <- jobs[:MAX_PLAYER_NAMES_TO_IDS]
+	fallback.PlayerNameToIDJobCh <- jobs[MAX_PLAYER_NAMES_TO_IDS:]
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for _, job := range jobs {
+		select {
+		case result := <-job.ReturnCh:
+			response, ok := result.Get()
+			assert.True(t, ok)
+			if ok {
+				assert.Equal(t, job.LowerName, response.Name)
+			}
+		case <-deadline.C:
+			t.Fatal("timed out waiting for a queued fallback name lookup")
+		}
 	}
 }
 

--- a/common.go
+++ b/common.go
@@ -1059,7 +1059,8 @@ type FallbackAPIServer struct {
 	ProfilesGetManyByNameURL string
 	PlayerCertificateKeys    mapset.Set[rsa.PublicKey]
 	ProfilePropertyKeys      mapset.Set[rsa.PublicKey]
-	publicKeysFetcher        func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error)
+	AuthenticationKeys       mapset.Set[rsa.PublicKey]
+	publicKeysFetcher        func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error)
 
 	SkinDomains         mapset.Set[string]
 	GetTextureValidURIs mapset.Set[string]
@@ -1067,31 +1068,32 @@ type FallbackAPIServer struct {
 	PlayerNameValidator PlayerNameValidator
 }
 
-func (fallbackAPIServer *FallbackAPIServer) FetchPublicKeys() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+func (fallbackAPIServer *FallbackAPIServer) FetchPublicKeys() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
 	if fallbackAPIServer.publicKeysFetcher == nil {
-		return nil, nil, errors.New("fallback API server does not provide a public key fetcher")
+		return nil, nil, nil, errors.New("fallback API server does not provide a public key fetcher")
 	}
 	return fallbackAPIServer.publicKeysFetcher()
 }
 
-func fetchPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+func fetchPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
 	playerCertificateKeys := mapset.NewSet[rsa.PublicKey]()
 	profilePropertyKeys := mapset.NewSet[rsa.PublicKey]()
+	authenticationKeys := mapset.NewSet[rsa.PublicKey]()
 
 	res, err := MakeHTTPClient().Get(url)
 	if err != nil {
-		return nil, nil, fmt.Errorf("couldn't access fallback API server at %s: %s\n", url, err)
+		return nil, nil, nil, fmt.Errorf("couldn't access fallback API server at %s: %s\n", url, err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("request to fallback API server at %s resulted in status code %d\n", url, res.StatusCode)
+		return nil, nil, nil, fmt.Errorf("request to fallback API server at %s resulted in status code %d\n", url, res.StatusCode)
 	}
 
 	var publicKeysRes PublicKeysResponse
 	err = json.NewDecoder(res.Body).Decode(&publicKeysRes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("received invalid response from fallback API server at %s\n", url)
+		return nil, nil, nil, fmt.Errorf("received invalid response from fallback API server at %s\n", url)
 	}
 
 	for _, serializedKey := range publicKeysRes.ProfilePropertyKeys {
@@ -1110,45 +1112,55 @@ func fetchPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.Publ
 		}
 		playerCertificateKeys.Add(*publicKey)
 	}
+	for _, serializedKey := range publicKeysRes.AuthenticationKeys {
+		publicKey, err := SerializedKeyToPublicKey(serializedKey)
+		if err != nil {
+			log.Printf("Received invalid authentication key from fallback API server at %s: %s\n", url, err)
+			continue
+		}
+		authenticationKeys.Add(*publicKey)
+	}
 	log.Printf("Fetched public keys from fallback API server at %s", url)
-	return playerCertificateKeys, profilePropertyKeys, nil
+	return playerCertificateKeys, profilePropertyKeys, authenticationKeys, nil
 }
 
-func authlibInjectorPublicKeys(publicKeyPEM string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+func authlibInjectorPublicKeys(publicKeyPEM string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
 	publicKey, err := parsePEMRSAPublicKey(publicKeyPEM)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	playerCertificateKeys := mapset.NewSet[rsa.PublicKey]()
 	profilePropertyKeys := mapset.NewSet[rsa.PublicKey]()
+	authenticationKeys := mapset.NewSet[rsa.PublicKey]()
 	playerCertificateKeys.Add(*publicKey)
 	profilePropertyKeys.Add(*publicKey)
-	return playerCertificateKeys, profilePropertyKeys, nil
+	authenticationKeys.Add(*publicKey)
+	return playerCertificateKeys, profilePropertyKeys, authenticationKeys, nil
 }
 
-func fetchAuthlibInjectorPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+func fetchAuthlibInjectorPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
 	res, err := MakeHTTPClient().Get(url)
 	if err != nil {
-		return nil, nil, fmt.Errorf("couldn't access fallback API server at %s: %s", url, err)
+		return nil, nil, nil, fmt.Errorf("couldn't access fallback API server at %s: %s", url, err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("request to fallback API server at %s resulted in status code %d", url, res.StatusCode)
+		return nil, nil, nil, fmt.Errorf("request to fallback API server at %s resulted in status code %d", url, res.StatusCode)
 	}
 
 	var response authlibInjectorResponse
 	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
-		return nil, nil, fmt.Errorf("received invalid response from fallback API server at %s", url)
+		return nil, nil, nil, fmt.Errorf("received invalid response from fallback API server at %s", url)
 	}
 
-	playerCertificateKeys, profilePropertyKeys, err := authlibInjectorPublicKeys(response.SignaturePublickey)
+	playerCertificateKeys, profilePropertyKeys, authenticationKeys, err := authlibInjectorPublicKeys(response.SignaturePublickey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("received invalid public key from fallback API server at %s: %s", url, err)
+		return nil, nil, nil, fmt.Errorf("received invalid public key from fallback API server at %s: %s", url, err)
 	}
 	log.Printf("Fetched public keys from fallback API server at %s", url)
-	return playerCertificateKeys, profilePropertyKeys, nil
+	return playerCertificateKeys, profilePropertyKeys, authenticationKeys, nil
 }
 
 func parsePEMRSAPublicKey(publicKeyPEM string) (*rsa.PublicKey, error) {
@@ -1186,7 +1198,8 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 	var profilesGetManyByNameURL string
 	playerCertificateKeys := mapset.NewSet[rsa.PublicKey]()
 	profilePropertyKeys := mapset.NewSet[rsa.PublicKey]()
-	var publicKeysFetcher func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error)
+	authenticationKeys := mapset.NewSet[rsa.PublicKey]()
+	var publicKeysFetcher func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error)
 	skinDomains := mapset.NewSet[string]()
 	getTextureValidURIs := mapset.NewSet[string]()
 
@@ -1219,11 +1232,11 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		profilesGetManyByNameURL = discoveryResponse.Discovery.Profiles.Endpoints.GetManyByName.URI
 
 		publicKeysURL := discoveryResponse.Discovery.Authentication.Endpoints.GetPublicKeys.URI
-		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
 			return fetchPublicKeys(publicKeysURL)
 		}
 
-		playerCertificateKeys, profilePropertyKeys, err = publicKeysFetcher()
+		playerCertificateKeys, profilePropertyKeys, authenticationKeys, err = publicKeysFetcher()
 		if err != nil {
 			log.Printf("Error fetching public keys from FallbackAPIServer %s: %s", config.Nickname, err)
 		}
@@ -1271,11 +1284,11 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		profilesGetManyByNameURL = aliLocation + "/api/profiles/minecraft"
 
 		// TODO https://github.com/yushijinhun/authlib-injector/pull/279
-		playerCertificateKeys, profilePropertyKeys, err = authlibInjectorPublicKeys(aliResponse.SignaturePublickey)
+		playerCertificateKeys, profilePropertyKeys, authenticationKeys, err = authlibInjectorPublicKeys(aliResponse.SignaturePublickey)
 		if err != nil {
 			log.Printf("Received invalid public key from fallback API server %s: %s\n", config.Nickname, err)
 		}
-		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
 			return fetchAuthlibInjectorPublicKeys(aliLocation)
 		}
 
@@ -1303,11 +1316,11 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		profilesGetManyByNameURL = legacy.AccountURL + "/profiles/minecraft"
 
 		publicKeysURL := legacy.ServicesURL + "/publickeys"
-		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
 			return fetchPublicKeys(publicKeysURL)
 		}
 		var err error
-		playerCertificateKeys, profilePropertyKeys, err = publicKeysFetcher()
+		playerCertificateKeys, profilePropertyKeys, authenticationKeys, err = publicKeysFetcher()
 		if err != nil {
 			log.Printf("Error fetching public keys from FallbackAPIServer %s: %s", config.Nickname, err)
 		}
@@ -1339,6 +1352,7 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		ProfilesGetManyByNameURL: profilesGetManyByNameURL,
 		ProfilePropertyKeys:      profilePropertyKeys,
 		PlayerCertificateKeys:    playerCertificateKeys,
+		AuthenticationKeys:       authenticationKeys,
 		publicKeysFetcher:        publicKeysFetcher,
 
 		SkinDomains:         skinDomains,
@@ -1356,12 +1370,13 @@ func (app *App) RefreshFallbackPublicKeys() {
 	type refreshedPublicKeys struct {
 		playerCertificateKeys mapset.Set[rsa.PublicKey]
 		profilePropertyKeys   mapset.Set[rsa.PublicKey]
+		authenticationKeys    mapset.Set[rsa.PublicKey]
 	}
 
 	refreshed := make(map[string]refreshedPublicKeys, len(app.FallbackAPIServerNicknames))
 	for _, nickname := range app.FallbackAPIServerNicknames {
 		fallbackAPIServer := app.FallbackAPIServers[nickname]
-		playerCertificateKeys, profilePropertyKeys, err := fallbackAPIServer.FetchPublicKeys()
+		playerCertificateKeys, profilePropertyKeys, authenticationKeys, err := fallbackAPIServer.FetchPublicKeys()
 		if err != nil {
 			log.Printf("Error refreshing public keys from FallbackAPIServer %s: %s", nickname, err)
 			continue
@@ -1369,6 +1384,7 @@ func (app *App) RefreshFallbackPublicKeys() {
 		refreshed[nickname] = refreshedPublicKeys{
 			playerCertificateKeys: playerCertificateKeys,
 			profilePropertyKeys:   profilePropertyKeys,
+			authenticationKeys:    authenticationKeys,
 		}
 	}
 
@@ -1379,10 +1395,12 @@ func (app *App) RefreshFallbackPublicKeys() {
 		fallbackAPIServer := app.FallbackAPIServers[nickname]
 		fallbackAPIServer.PlayerCertificateKeys = publicKeys.playerCertificateKeys
 		fallbackAPIServer.ProfilePropertyKeys = publicKeys.profilePropertyKeys
+		fallbackAPIServer.AuthenticationKeys = publicKeys.authenticationKeys
 	}
 
 	playerCertificateKeys := []rsa.PublicKey{app.PrivateKey.PublicKey}
 	profilePropertyKeys := []rsa.PublicKey{app.PrivateKey.PublicKey}
+	authenticationKeys := []rsa.PublicKey{app.PrivateKey.PublicKey}
 	for _, nickname := range app.FallbackAPIServerNicknames {
 		fallbackAPIServer := app.FallbackAPIServers[nickname]
 		for _, publicKey := range fallbackAPIServer.ProfilePropertyKeys.ToSlice() {
@@ -1395,9 +1413,15 @@ func (app *App) RefreshFallbackPublicKeys() {
 				playerCertificateKeys = append(playerCertificateKeys, publicKey)
 			}
 		}
+		for _, publicKey := range fallbackAPIServer.AuthenticationKeys.ToSlice() {
+			if !ContainsPublicKey(authenticationKeys, &publicKey) {
+				authenticationKeys = append(authenticationKeys, publicKey)
+			}
+		}
 	}
 	app.PlayerCertificateKeys = playerCertificateKeys
 	app.ProfilePropertyKeys = profilePropertyKeys
+	app.AuthenticationKeys = authenticationKeys
 }
 
 func (app *App) NewPlayerUUID(playerName string) (string, error) {

--- a/common.go
+++ b/common.go
@@ -38,6 +38,7 @@ import (
 
 const MAX_PLAYER_NAMES_TO_IDS = 10
 const MAX_PLAYER_NAMES_TO_IDS_INTERVAL = 1 * time.Second
+const FALLBACK_PUBLIC_KEYS_REFRESH_INTERVAL = 24 * time.Hour
 
 const CONTEXT_KEY_REQ = "DraslReq"
 const CONTEXT_KEY_LOCALE = "DraslLocale"
@@ -1058,11 +1059,19 @@ type FallbackAPIServer struct {
 	ProfilesGetManyByNameURL string
 	PlayerCertificateKeys    mapset.Set[rsa.PublicKey]
 	ProfilePropertyKeys      mapset.Set[rsa.PublicKey]
+	publicKeysFetcher        func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error)
 
 	SkinDomains         mapset.Set[string]
 	GetTextureValidURIs mapset.Set[string]
 
 	PlayerNameValidator PlayerNameValidator
+}
+
+func (fallbackAPIServer *FallbackAPIServer) FetchPublicKeys() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+	if fallbackAPIServer.publicKeysFetcher == nil {
+		return nil, nil, errors.New("fallback API server does not provide a public key fetcher")
+	}
+	return fallbackAPIServer.publicKeysFetcher()
 }
 
 func fetchPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
@@ -1105,6 +1114,43 @@ func fetchPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.Publ
 	return playerCertificateKeys, profilePropertyKeys, nil
 }
 
+func authlibInjectorPublicKeys(publicKeyPEM string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+	publicKey, err := parsePEMRSAPublicKey(publicKeyPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	playerCertificateKeys := mapset.NewSet[rsa.PublicKey]()
+	profilePropertyKeys := mapset.NewSet[rsa.PublicKey]()
+	playerCertificateKeys.Add(*publicKey)
+	profilePropertyKeys.Add(*publicKey)
+	return playerCertificateKeys, profilePropertyKeys, nil
+}
+
+func fetchAuthlibInjectorPublicKeys(url string) (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+	res, err := MakeHTTPClient().Get(url)
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't access fallback API server at %s: %s", url, err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("request to fallback API server at %s resulted in status code %d", url, res.StatusCode)
+	}
+
+	var response authlibInjectorResponse
+	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+		return nil, nil, fmt.Errorf("received invalid response from fallback API server at %s", url)
+	}
+
+	playerCertificateKeys, profilePropertyKeys, err := authlibInjectorPublicKeys(response.SignaturePublickey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("received invalid public key from fallback API server at %s: %s", url, err)
+	}
+	log.Printf("Fetched public keys from fallback API server at %s", url)
+	return playerCertificateKeys, profilePropertyKeys, nil
+}
+
 func parsePEMRSAPublicKey(publicKeyPEM string) (*rsa.PublicKey, error) {
 	block, _ := pem.Decode([]byte(publicKeyPEM))
 	if block == nil {
@@ -1140,6 +1186,7 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 	var profilesGetManyByNameURL string
 	playerCertificateKeys := mapset.NewSet[rsa.PublicKey]()
 	profilePropertyKeys := mapset.NewSet[rsa.PublicKey]()
+	var publicKeysFetcher func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error)
 	skinDomains := mapset.NewSet[string]()
 	getTextureValidURIs := mapset.NewSet[string]()
 
@@ -1172,8 +1219,11 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		profilesGetManyByNameURL = discoveryResponse.Discovery.Profiles.Endpoints.GetManyByName.URI
 
 		publicKeysURL := discoveryResponse.Discovery.Authentication.Endpoints.GetPublicKeys.URI
+		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+			return fetchPublicKeys(publicKeysURL)
+		}
 
-		playerCertificateKeys, profilePropertyKeys, err = fetchPublicKeys(publicKeysURL)
+		playerCertificateKeys, profilePropertyKeys, err = publicKeysFetcher()
 		if err != nil {
 			log.Printf("Error fetching public keys from FallbackAPIServer %s: %s", config.Nickname, err)
 		}
@@ -1221,12 +1271,12 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		profilesGetManyByNameURL = aliLocation + "/api/profiles/minecraft"
 
 		// TODO https://github.com/yushijinhun/authlib-injector/pull/279
-		publicKey, err := parsePEMRSAPublicKey(aliResponse.SignaturePublickey)
+		playerCertificateKeys, profilePropertyKeys, err = authlibInjectorPublicKeys(aliResponse.SignaturePublickey)
 		if err != nil {
 			log.Printf("Received invalid public key from fallback API server %s: %s\n", config.Nickname, err)
-		} else {
-			playerCertificateKeys.Add(*publicKey)
-			profilePropertyKeys.Add(*publicKey)
+		}
+		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+			return fetchAuthlibInjectorPublicKeys(aliLocation)
 		}
 
 		for _, skinDomain := range aliResponse.SkinDomains {
@@ -1253,8 +1303,11 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		profilesGetManyByNameURL = legacy.AccountURL + "/profiles/minecraft"
 
 		publicKeysURL := legacy.ServicesURL + "/publickeys"
+		publicKeysFetcher = func() (mapset.Set[rsa.PublicKey], mapset.Set[rsa.PublicKey], error) {
+			return fetchPublicKeys(publicKeysURL)
+		}
 		var err error
-		playerCertificateKeys, profilePropertyKeys, err = fetchPublicKeys(publicKeysURL)
+		playerCertificateKeys, profilePropertyKeys, err = publicKeysFetcher()
 		if err != nil {
 			log.Printf("Error fetching public keys from FallbackAPIServer %s: %s", config.Nickname, err)
 		}
@@ -1286,6 +1339,7 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 		ProfilesGetManyByNameURL: profilesGetManyByNameURL,
 		ProfilePropertyKeys:      profilePropertyKeys,
 		PlayerCertificateKeys:    playerCertificateKeys,
+		publicKeysFetcher:        publicKeysFetcher,
 
 		SkinDomains:         skinDomains,
 		GetTextureValidURIs: getTextureValidURIs,
@@ -1296,6 +1350,54 @@ func NewFallbackAPIServer(config *FallbackAPIServerConfig) (FallbackAPIServer, e
 			MaxPlayerNameLength:  config.MaxPlayerNameLength,
 		},
 	}, nil
+}
+
+func (app *App) RefreshFallbackPublicKeys() {
+	type refreshedPublicKeys struct {
+		playerCertificateKeys mapset.Set[rsa.PublicKey]
+		profilePropertyKeys   mapset.Set[rsa.PublicKey]
+	}
+
+	refreshed := make(map[string]refreshedPublicKeys, len(app.FallbackAPIServerNicknames))
+	for _, nickname := range app.FallbackAPIServerNicknames {
+		fallbackAPIServer := app.FallbackAPIServers[nickname]
+		playerCertificateKeys, profilePropertyKeys, err := fallbackAPIServer.FetchPublicKeys()
+		if err != nil {
+			log.Printf("Error refreshing public keys from FallbackAPIServer %s: %s", nickname, err)
+			continue
+		}
+		refreshed[nickname] = refreshedPublicKeys{
+			playerCertificateKeys: playerCertificateKeys,
+			profilePropertyKeys:   profilePropertyKeys,
+		}
+	}
+
+	app.PublicKeysMutex.Lock()
+	defer app.PublicKeysMutex.Unlock()
+
+	for nickname, publicKeys := range refreshed {
+		fallbackAPIServer := app.FallbackAPIServers[nickname]
+		fallbackAPIServer.PlayerCertificateKeys = publicKeys.playerCertificateKeys
+		fallbackAPIServer.ProfilePropertyKeys = publicKeys.profilePropertyKeys
+	}
+
+	playerCertificateKeys := []rsa.PublicKey{app.PrivateKey.PublicKey}
+	profilePropertyKeys := []rsa.PublicKey{app.PrivateKey.PublicKey}
+	for _, nickname := range app.FallbackAPIServerNicknames {
+		fallbackAPIServer := app.FallbackAPIServers[nickname]
+		for _, publicKey := range fallbackAPIServer.ProfilePropertyKeys.ToSlice() {
+			if !ContainsPublicKey(profilePropertyKeys, &publicKey) {
+				profilePropertyKeys = append(profilePropertyKeys, publicKey)
+			}
+		}
+		for _, publicKey := range fallbackAPIServer.PlayerCertificateKeys.ToSlice() {
+			if !ContainsPublicKey(playerCertificateKeys, &publicKey) {
+				playerCertificateKeys = append(playerCertificateKeys, publicKey)
+			}
+		}
+	}
+	app.PlayerCertificateKeys = playerCertificateKeys
+	app.ProfilePropertyKeys = profilePropertyKeys
 }
 
 func (app *App) NewPlayerUUID(playerName string) (string, error) {
@@ -1353,6 +1455,15 @@ func (app *App) RunPeriodicTasks() {
 
 		for range ticker.C {
 			app.cleanupHeartbeatLRU()
+		}
+	}()
+
+	go func() {
+		ticker := time.NewTicker(FALLBACK_PUBLIC_KEYS_REFRESH_INTERVAL)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			app.RefreshFallbackPublicKeys()
 		}
 	}()
 }

--- a/fallback_api_server_test.go
+++ b/fallback_api_server_test.go
@@ -54,12 +54,14 @@ func TestFallbackAPIServerLegacy(t *testing.T) {
 	assert.Equal(t, ts.AuxApp.SessionURL+"/session/minecraft/hasJoined", fb.SessionVerifyURL)
 	assert.Equal(t, ts.AuxApp.AccountURL+"/profiles/minecraft", fb.ProfilesGetManyByNameURL)
 
-	// The aux's public key should be present in both key sets, fetched from
-	// the aux's /publickeys endpoint.
+	// The aux's public key should be present in all three key sets, fetched
+	// from the aux's /publickeys endpoint.
 	assert.Equal(t, 1, fb.ProfilePropertyKeys.Cardinality())
 	assert.Equal(t, 1, fb.PlayerCertificateKeys.Cardinality())
+	assert.Equal(t, 1, fb.AuthenticationKeys.Cardinality())
 	assert.True(t, fallbackKeyContains(fb.ProfilePropertyKeys, ts.AuxApp.PrivateKey.PublicKey))
 	assert.True(t, fallbackKeyContains(fb.PlayerCertificateKeys, ts.AuxApp.PrivateKey.PublicKey))
+	assert.True(t, fallbackKeyContains(fb.AuthenticationKeys, ts.AuxApp.PrivateKey.PublicKey))
 
 	// Skin domains and texture valid URIs derived from the configured
 	// SkinDomains list.
@@ -104,11 +106,13 @@ func TestFallbackAPIServerDiscovery(t *testing.T) {
 	assert.Equal(t, ts.AuxApp.SessionURL+"/session/minecraft/hasJoined", fb.SessionVerifyURL)
 	assert.Equal(t, ts.AuxApp.AccountURL+"/profiles/minecraft", fb.ProfilesGetManyByNameURL)
 
-	// The aux's public key should be present in both key sets.
+	// The aux's public key should be present in all three key sets.
 	assert.Equal(t, 1, fb.ProfilePropertyKeys.Cardinality())
 	assert.Equal(t, 1, fb.PlayerCertificateKeys.Cardinality())
+	assert.Equal(t, 1, fb.AuthenticationKeys.Cardinality())
 	assert.True(t, fallbackKeyContains(fb.ProfilePropertyKeys, ts.AuxApp.PrivateKey.PublicKey))
 	assert.True(t, fallbackKeyContains(fb.PlayerCertificateKeys, ts.AuxApp.PrivateKey.PublicKey))
+	assert.True(t, fallbackKeyContains(fb.AuthenticationKeys, ts.AuxApp.PrivateKey.PublicKey))
 
 	// Look up an aux player by UUID through the main server.
 	{
@@ -148,12 +152,14 @@ func TestFallbackAPIServerAuthlibInjector(t *testing.T) {
 	assert.Equal(t, ts.AuxApp.AuthlibInjectorURL+"/sessionserver/session/minecraft/hasJoined", fb.SessionVerifyURL)
 	assert.Equal(t, ts.AuxApp.AuthlibInjectorURL+"/api/profiles/minecraft", fb.ProfilesGetManyByNameURL)
 
-	// The aux's public key should be present in both key sets (ALI form
-	// populates both from the single SignaturePublickey).
+	// The aux's public key should be present in all three key sets (ALI form
+	// populates all of them from the single SignaturePublickey).
 	assert.Equal(t, 1, fb.ProfilePropertyKeys.Cardinality())
 	assert.Equal(t, 1, fb.PlayerCertificateKeys.Cardinality())
+	assert.Equal(t, 1, fb.AuthenticationKeys.Cardinality())
 	assert.True(t, fallbackKeyContains(fb.ProfilePropertyKeys, ts.AuxApp.PrivateKey.PublicKey))
 	assert.True(t, fallbackKeyContains(fb.PlayerCertificateKeys, ts.AuxApp.PrivateKey.PublicKey))
+	assert.True(t, fallbackKeyContains(fb.AuthenticationKeys, ts.AuxApp.PrivateKey.PublicKey))
 
 	// Skin domains and texture valid URIs derived from the aux's
 	// authlib-injector response.

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ type App struct {
 	PublicKeysMutex            sync.RWMutex
 	PlayerCertificateKeys      []rsa.PublicKey
 	ProfilePropertyKeys        []rsa.PublicKey
+	AuthenticationKeys         []rsa.PublicKey
 	PrivateKey                 *rsa.PrivateKey
 	PrivateKeyB3Sum256         [256 / 8]byte
 	PrivateKeyB3Sum512         [512 / 8]byte
@@ -540,8 +541,10 @@ func setup(config *Config) *App {
 	fallbackAPIServerNicknames := make([]string, 0, len(config.FallbackAPIServers))
 	playerCertificateKeys := make([]rsa.PublicKey, 0, 1)
 	profilePropertyKeys := make([]rsa.PublicKey, 0, 1)
+	authenticationKeys := make([]rsa.PublicKey, 0, 1)
 	profilePropertyKeys = append(profilePropertyKeys, key.PublicKey)
 	playerCertificateKeys = append(playerCertificateKeys, key.PublicKey)
+	authenticationKeys = append(authenticationKeys, key.PublicKey)
 
 	for _, fallbackAPIServerConfig := range config.FallbackAPIServers {
 		fallbackAPIServer, err := NewFallbackAPIServer(&fallbackAPIServerConfig)
@@ -557,6 +560,11 @@ func setup(config *Config) *App {
 		for _, publicKey := range fallbackAPIServer.PlayerCertificateKeys.ToSlice() {
 			if !ContainsPublicKey(playerCertificateKeys, &publicKey) {
 				playerCertificateKeys = append(playerCertificateKeys, publicKey)
+			}
+		}
+		for _, publicKey := range fallbackAPIServer.AuthenticationKeys.ToSlice() {
+			if !ContainsPublicKey(authenticationKeys, &publicKey) {
+				authenticationKeys = append(authenticationKeys, publicKey)
 			}
 		}
 		fallbackAPIServers[fallbackAPIServerConfig.Nickname] = &fallbackAPIServer
@@ -637,6 +645,7 @@ func setup(config *Config) *App {
 		PublicURL:                  Unwrap(url.JoinPath(config.BaseURL, "web/public")),
 		PlayerCertificateKeys:      playerCertificateKeys,
 		ProfilePropertyKeys:        profilePropertyKeys,
+		AuthenticationKeys:         authenticationKeys,
 		AccountURL:                 Unwrap(url.JoinPath(config.BaseURL, "account")),
 		AuthURL:                    Unwrap(url.JoinPath(config.BaseURL, "auth")),
 		ServicesURL:                Unwrap(url.JoinPath(config.BaseURL, "services")),

--- a/main.go
+++ b/main.go
@@ -548,6 +548,16 @@ func setup(config *Config) *App {
 			log.Printf("Error initializing FallbackAPIServer %s: %s", fallbackAPIServerConfig.Nickname, err)
 			continue
 		}
+		for _, publicKey := range fallbackAPIServer.ProfilePropertyKeys.ToSlice() {
+			if !ContainsPublicKey(profilePropertyKeys, &publicKey) {
+				profilePropertyKeys = append(profilePropertyKeys, publicKey)
+			}
+		}
+		for _, publicKey := range fallbackAPIServer.PlayerCertificateKeys.ToSlice() {
+			if !ContainsPublicKey(playerCertificateKeys, &publicKey) {
+				playerCertificateKeys = append(playerCertificateKeys, publicKey)
+			}
+		}
 		fallbackAPIServers[fallbackAPIServerConfig.Nickname] = &fallbackAPIServer
 		fallbackAPIServerNicknames = append(fallbackAPIServerNicknames, fallbackAPIServerConfig.Nickname)
 	}

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ type App struct {
 	Config                     *Config
 	ValidPlayerNameRegex       *regexp.Regexp
 	Constants                  *ConstantsType
+	PublicKeysMutex            sync.RWMutex
 	PlayerCertificateKeys      []rsa.PublicKey
 	ProfilePropertyKeys        []rsa.PublicKey
 	PrivateKey                 *rsa.PrivateKey

--- a/messages.pot
+++ b/messages.pot
@@ -129,11 +129,11 @@ msgstr ""
 msgid "Back to your account"
 msgstr ""
 
-#: common.go:215
+#: common.go:216
 msgid "Bad Gateway"
 msgstr ""
 
-#: common.go:195
+#: common.go:196
 msgid "Bad Request"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "For example, the full command you use to start the server might be:"
 msgstr ""
 
-#: common.go:199
+#: common.go:200
 msgid "Forbidden"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgstr ""
 msgid "Incorrect password."
 msgstr ""
 
-#: api.go:42 common.go:181 common.go:213 front.go:378
+#: api.go:42 common.go:182 common.go:214 front.go:378
 msgid "Internal server error"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Max player count must be an integer."
 msgstr ""
 
-#: common.go:203
+#: common.go:204
 msgid "Method Not Allowed"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgstr ""
 msgid "No skin yet."
 msgstr ""
 
-#: common.go:201
+#: common.go:202
 msgid "Not Found"
 msgstr ""
 
@@ -729,11 +729,11 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: common.go:207
+#: common.go:208
 msgid "Request Entity Too Large"
 msgstr ""
 
-#: common.go:205
+#: common.go:206
 msgid "Request Timeout"
 msgstr ""
 
@@ -749,7 +749,7 @@ msgstr ""
 msgid "See <a href=\"{{ index . 0 }}\">the %s API documentation</a>"
 msgstr ""
 
-#: common.go:217
+#: common.go:218
 msgid "Service Unavailable"
 msgstr ""
 
@@ -861,11 +861,11 @@ msgstr ""
 msgid "To demote a default admin, edit the %s configuration."
 msgstr ""
 
-#: common.go:211
+#: common.go:212
 msgid "Too Many Requests"
 msgstr ""
 
-#: main.go:163
+#: main.go:165
 msgid "Too many requests. Try again later."
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr ""
 msgid "UUID or player name. If you don't set a skin or cape, this player's skin on one of the fallback API servers will be used instead."
 msgstr ""
 
-#: common.go:197
+#: common.go:198
 msgid "Unauthorized"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Unknown invite code"
 msgstr ""
 
-#: common.go:209
+#: common.go:210
 msgid "Unsupported Media Type"
 msgstr ""
 
@@ -1027,27 +1027,27 @@ msgstr ""
 msgid "Your players"
 msgstr ""
 
-#: common.go:1036 model.go:118 model.go:193
+#: common.go:1037 model.go:118 model.go:193
 msgid "can't be blank"
 msgstr ""
 
-#: common.go:1042 model.go:124
+#: common.go:1043 model.go:124
 msgid "can't be longer than %d character"
 msgid_plural "can't be longer than %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: common.go:1039 model.go:121
+#: common.go:1040 model.go:121
 msgid "can't be shorter than %d character"
 msgid_plural "can't be shorter than %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: common.go:442
+#: common.go:443
 msgid "cape must not be greater than %d pixels wide"
 msgstr ""
 
-#: common.go:445
+#: common.go:446
 msgid "cape size must be a multiple of %[1]d pixels wide by %[2]d pixels high"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgid_plural "must be longer than %d characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: common.go:1046 model.go:128
+#: common.go:1047 model.go:128
 msgid "must match the following regular expression: %s"
 msgstr ""
 
@@ -1153,11 +1153,11 @@ msgstr ""
 msgid "skin does not match"
 msgstr ""
 
-#: common.go:415
+#: common.go:416
 msgid "skin must not be greater than %d pixels wide"
 msgstr ""
 
-#: common.go:418
+#: common.go:419
 msgid "skin size must be a multiple of %[1]d pixels wide by %[2]d or %[3]d pixels high"
 msgstr ""
 

--- a/services.go
+++ b/services.go
@@ -551,6 +551,7 @@ func ServicesChangeName(app *App) func(c *echo.Context) error {
 type PublicKeysResponse struct {
 	PlayerCertificateKeys []SerializedKey `json:"playerCertificateKeys"`
 	ProfilePropertyKeys   []SerializedKey `json:"profilePropertyKeys"`
+	AuthenticationKeys    []SerializedKey `json:"authenticationKeys"`
 }
 
 type SerializedKey struct {
@@ -581,10 +582,12 @@ func ServicesPublicKeys(app *App) func(c *echo.Context) error {
 		app.PublicKeysMutex.RLock()
 		profilePropertyKeys := append([]rsa.PublicKey(nil), app.ProfilePropertyKeys...)
 		playerCertificateKeys := append([]rsa.PublicKey(nil), app.PlayerCertificateKeys...)
+		authenticationKeys := append([]rsa.PublicKey(nil), app.AuthenticationKeys...)
 		app.PublicKeysMutex.RUnlock()
 
 		serializedProfilePropertyKeys := make([]SerializedKey, 0, len(profilePropertyKeys))
 		serializedPlayerCertificateKeys := make([]SerializedKey, 0, len(playerCertificateKeys))
+		serializedAuthenticationKeys := make([]SerializedKey, 0, len(authenticationKeys))
 
 		for _, key := range profilePropertyKeys {
 			publicKeyDer := Unwrap(x509.MarshalPKIXPublicKey(&key))
@@ -596,10 +599,16 @@ func ServicesPublicKeys(app *App) func(c *echo.Context) error {
 			serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
 			serializedPlayerCertificateKeys = append(serializedPlayerCertificateKeys, serializedKey)
 		}
+		for _, key := range authenticationKeys {
+			publicKeyDer := Unwrap(x509.MarshalPKIXPublicKey(&key))
+			serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
+			serializedAuthenticationKeys = append(serializedAuthenticationKeys, serializedKey)
+		}
 
 		responseBlob := Unwrap(json.Marshal(PublicKeysResponse{
 			PlayerCertificateKeys: serializedPlayerCertificateKeys,
 			ProfilePropertyKeys:   serializedProfilePropertyKeys,
+			AuthenticationKeys:    serializedAuthenticationKeys,
 		}))
 
 		return c.JSONBlob(http.StatusOK, responseBlob)

--- a/services.go
+++ b/services.go
@@ -577,26 +577,31 @@ func SerializedKeyToPublicKey(serializedKey SerializedKey) (*rsa.PublicKey, erro
 // GET /publickeys
 // https://minecraft.wiki/w/Mojang_API#Get_Mojang_public_keys
 func ServicesPublicKeys(app *App) func(c *echo.Context) error {
-	serializedProfilePropertyKeys := make([]SerializedKey, 0, len(app.ProfilePropertyKeys))
-	serializedPlayerCertificateKeys := make([]SerializedKey, 0, len(app.PlayerCertificateKeys))
-
-	for _, key := range app.ProfilePropertyKeys {
-		publicKeyDer := Unwrap(x509.MarshalPKIXPublicKey(&key))
-		serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
-		serializedProfilePropertyKeys = append(serializedProfilePropertyKeys, serializedKey)
-	}
-	for _, key := range app.PlayerCertificateKeys {
-		publicKeyDer := Unwrap(x509.MarshalPKIXPublicKey(&key))
-		serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
-		serializedPlayerCertificateKeys = append(serializedPlayerCertificateKeys, serializedKey)
-	}
-
-	responseBlob := Unwrap(json.Marshal(PublicKeysResponse{
-		PlayerCertificateKeys: serializedPlayerCertificateKeys,
-		ProfilePropertyKeys:   serializedProfilePropertyKeys,
-	}))
-
 	return func(c *echo.Context) error {
+		app.PublicKeysMutex.RLock()
+		profilePropertyKeys := append([]rsa.PublicKey(nil), app.ProfilePropertyKeys...)
+		playerCertificateKeys := append([]rsa.PublicKey(nil), app.PlayerCertificateKeys...)
+		app.PublicKeysMutex.RUnlock()
+
+		serializedProfilePropertyKeys := make([]SerializedKey, 0, len(profilePropertyKeys))
+		serializedPlayerCertificateKeys := make([]SerializedKey, 0, len(playerCertificateKeys))
+
+		for _, key := range profilePropertyKeys {
+			publicKeyDer := Unwrap(x509.MarshalPKIXPublicKey(&key))
+			serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
+			serializedProfilePropertyKeys = append(serializedProfilePropertyKeys, serializedKey)
+		}
+		for _, key := range playerCertificateKeys {
+			publicKeyDer := Unwrap(x509.MarshalPKIXPublicKey(&key))
+			serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
+			serializedPlayerCertificateKeys = append(serializedPlayerCertificateKeys, serializedKey)
+		}
+
+		responseBlob := Unwrap(json.Marshal(PublicKeysResponse{
+			PlayerCertificateKeys: serializedPlayerCertificateKeys,
+			ProfilePropertyKeys:   serializedProfilePropertyKeys,
+		}))
+
 		return c.JSONBlob(http.StatusOK, responseBlob)
 	}
 }

--- a/services.go
+++ b/services.go
@@ -585,7 +585,7 @@ func ServicesPublicKeys(app *App) func(c *echo.Context) error {
 		serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
 		serializedProfilePropertyKeys = append(serializedProfilePropertyKeys, serializedKey)
 	}
-	for _, key := range app.ProfilePropertyKeys {
+	for _, key := range app.PlayerCertificateKeys {
 		publicKeyDer := Unwrap(x509.MarshalPKIXPublicKey(&key))
 		serializedKey := SerializedKey{PublicKey: base64.StdEncoding.EncodeToString(publicKeyDer)}
 		serializedPlayerCertificateKeys = append(serializedPlayerCertificateKeys, serializedKey)

--- a/services_test.go
+++ b/services_test.go
@@ -528,13 +528,19 @@ func (ts *TestSuite) testServicesPublicKeys(t *testing.T) {
 	for _, key := range response.ProfilePropertyKeys {
 		validateSerializedKey(t, key.PublicKey)
 	}
+	for _, key := range response.AuthenticationKeys {
+		validateSerializedKey(t, key.PublicKey)
+	}
 
 	assert.Len(t, response.PlayerCertificateKeys, 2)
 	assert.Len(t, response.ProfilePropertyKeys, 2)
+	assert.Len(t, response.AuthenticationKeys, 2)
 	assert.True(t, serializedKeysContain(t, response.PlayerCertificateKeys, ts.App.PrivateKey.PublicKey))
 	assert.True(t, serializedKeysContain(t, response.PlayerCertificateKeys, ts.AuxApp.PrivateKey.PublicKey))
 	assert.True(t, serializedKeysContain(t, response.ProfilePropertyKeys, ts.App.PrivateKey.PublicKey))
 	assert.True(t, serializedKeysContain(t, response.ProfilePropertyKeys, ts.AuxApp.PrivateKey.PublicKey))
+	assert.True(t, serializedKeysContain(t, response.AuthenticationKeys, ts.App.PrivateKey.PublicKey))
+	assert.True(t, serializedKeysContain(t, response.AuthenticationKeys, ts.AuxApp.PrivateKey.PublicKey))
 }
 
 func (ts *TestSuite) testServicesIDToPlayerName(t *testing.T) {

--- a/services_test.go
+++ b/services_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/assert"
 	"mime/multipart"
 	"net/http"
@@ -473,6 +476,45 @@ func validateSerializedKey(t *testing.T, serializedKey string) {
 	assert.Nil(t, err)
 }
 
+func serializedKeysContain(t *testing.T, serializedKeys []SerializedKey, target rsa.PublicKey) bool {
+	for _, serializedKey := range serializedKeys {
+		key, err := SerializedKeyToPublicKey(serializedKey)
+		assert.Nil(t, err)
+		if err == nil && key.Equal(&target) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestServicesPublicKeysUsesDistinctKeySets(t *testing.T) {
+	profilePrivateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if !assert.NoError(t, err) {
+		return
+	}
+	certificatePrivateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	app := &App{
+		PlayerCertificateKeys: []rsa.PublicKey{certificatePrivateKey.PublicKey},
+		ProfilePropertyKeys:   []rsa.PublicKey{profilePrivateKey.PublicKey},
+	}
+	server := echo.New()
+	server.GET("/publickeys", ServicesPublicKeys(app))
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/publickeys", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response PublicKeysResponse
+	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
+	assert.Len(t, response.PlayerCertificateKeys, 1)
+	assert.Len(t, response.ProfilePropertyKeys, 1)
+	assert.True(t, serializedKeysContain(t, response.PlayerCertificateKeys, certificatePrivateKey.PublicKey))
+	assert.True(t, serializedKeysContain(t, response.ProfilePropertyKeys, profilePrivateKey.PublicKey))
+}
+
 func (ts *TestSuite) testServicesPublicKeys(t *testing.T) {
 	rec := ts.Get(t, ts.Server, "/publickeys", nil, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -486,6 +528,13 @@ func (ts *TestSuite) testServicesPublicKeys(t *testing.T) {
 	for _, key := range response.ProfilePropertyKeys {
 		validateSerializedKey(t, key.PublicKey)
 	}
+
+	assert.Len(t, response.PlayerCertificateKeys, 2)
+	assert.Len(t, response.ProfilePropertyKeys, 2)
+	assert.True(t, serializedKeysContain(t, response.PlayerCertificateKeys, ts.App.PrivateKey.PublicKey))
+	assert.True(t, serializedKeysContain(t, response.PlayerCertificateKeys, ts.AuxApp.PrivateKey.PublicKey))
+	assert.True(t, serializedKeysContain(t, response.ProfilePropertyKeys, ts.App.PrivateKey.PublicKey))
+	assert.True(t, serializedKeysContain(t, response.ProfilePropertyKeys, ts.AuxApp.PrivateKey.PublicKey))
 }
 
 func (ts *TestSuite) testServicesIDToPlayerName(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -5,8 +5,10 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -150,9 +152,12 @@ func (app *App) hasJoined(c *echo.Context, playerName string, serverID string, l
 				continue
 			}
 
-			params := url.Values{}
-			params.Add("username", playerName)
-			params.Add("serverId", serverID)
+			params := hasJoinedURL.Query()
+			params.Set("username", playerName)
+			params.Set("serverId", serverID)
+			if ip := (*c).QueryParam("ip"); ip != "" {
+				params.Set("ip", ip)
+			}
 			hasJoinedURL.RawQuery = params.Encode()
 
 			res, err := MakeHTTPClient().Get(hasJoinedURL.String())
@@ -160,15 +165,30 @@ func (app *App) hasJoined(c *echo.Context, playerName string, serverID string, l
 				log.Printf("Received invalid response from fallback API server at %s\n", hasJoinedURL.String())
 				continue
 			}
-			defer res.Body.Close()
-
 			if res.StatusCode == http.StatusOK {
+				body, err := io.ReadAll(res.Body)
+				res.Body.Close()
+				if err != nil {
+					log.Printf("Couldn't read response from fallback API server at %s: %s\n", hasJoinedURL.String(), err)
+					continue
+				}
+
+				var profile SessionProfileResponse
+				if err := json.Unmarshal(body, &profile); err != nil {
+					log.Printf("Received invalid response from fallback API server at %s: %s\n", hasJoinedURL.String(), err)
+					continue
+				}
+				if _, err := ParseUUID(profile.ID); err != nil || !strings.EqualFold(profile.Name, playerName) {
+					log.Printf("Received mismatched profile from fallback API server at %s\n", hasJoinedURL.String())
+					continue
+				}
+
 				if legacy {
 					return (*c).String(http.StatusOK, "YES")
-				} else {
-					return (*c).Stream(http.StatusOK, res.Header.Get("Content-Type"), res.Body)
 				}
+				return (*c).Blob(http.StatusOK, res.Header.Get("Content-Type"), body)
 			}
+			res.Body.Close()
 		}
 
 		if legacy {

--- a/session_test.go
+++ b/session_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -38,6 +39,73 @@ func TestSession(t *testing.T) {
 		defer ts.Teardown()
 
 		t.Run("Test /blockedservers", ts.testSessionBlockedServers)
+	}
+}
+
+func TestSessionFallbackHasJoined(t *testing.T) {
+	const (
+		playerName = "FallbackUser"
+		playerID   = "00000000000000000000000000000001"
+		clientIP   = "203.0.113.1"
+	)
+
+	queries := make(chan url.Values, 4)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		queries <- query
+		w.Header().Set("Content-Type", "application/json")
+
+		switch query.Get("serverId") {
+		case "invalid-json":
+			_, _ = w.Write([]byte("{"))
+		case "wrong-name":
+			_ = json.NewEncoder(w).Encode(SessionProfileResponse{ID: playerID, Name: "OtherUser"})
+		case "invalid-id":
+			_ = json.NewEncoder(w).Encode(SessionProfileResponse{ID: "invalid", Name: playerName})
+		default:
+			_ = json.NewEncoder(w).Encode(SessionProfileResponse{ID: playerID, Name: playerName})
+		}
+	}))
+	defer upstream.Close()
+
+	ts := &TestSuite{}
+	config := testConfig()
+	ts.Setup(config)
+	defer ts.Teardown()
+
+	fallbackConfig := defaultFallbackAPIServer()
+	fallbackConfig.Nickname = "Fallback"
+	ts.App.FallbackAPIServers["Fallback"] = &FallbackAPIServer{
+		Config:           &fallbackConfig,
+		SessionVerifyURL: upstream.URL,
+	}
+	ts.App.FallbackAPIServerNicknames = []string{"Fallback"}
+
+	request := func(serverID string) *httptest.ResponseRecorder {
+		path := "/session/minecraft/hasJoined?" + url.Values{
+			"username": {playerName},
+			"serverId": {serverID},
+			"ip":       {clientIP},
+		}.Encode()
+		return ts.Get(t, ts.Server, path, nil, nil)
+	}
+
+	rec := request("valid")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var response SessionProfileResponse
+	assert.Nil(t, json.NewDecoder(rec.Body).Decode(&response))
+	assert.Equal(t, playerID, response.ID)
+	assert.Equal(t, playerName, response.Name)
+	query := <-queries
+	assert.Equal(t, playerName, query.Get("username"))
+	assert.Equal(t, "valid", query.Get("serverId"))
+	assert.Equal(t, clientIP, query.Get("ip"))
+
+	for _, serverID := range []string{"invalid-json", "wrong-name", "invalid-id"} {
+		rec = request(serverID)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		query = <-queries
+		assert.Equal(t, clientIP, query.Get("ip"))
 	}
 }
 


### PR DESCRIPTION
This is a quick PR for:

- Fix Player profile keys being wrongly loaded as Certificate keys 
- Add a public key refresh every 24 hours (#265)
- Add the authenticationKeys to the /publickeys endpoint as well as adding fetching for those keys when available (#213)
- Fix query params for /has joined being broken